### PR TITLE
Quick patch draw artist circle

### DIFF
--- a/examples/base/game.py
+++ b/examples/base/game.py
@@ -53,16 +53,24 @@ ctx.visual.set_graph_visual(**graph_vis_config)
 for name, config in agent_vis_config.items():
     ctx.visual.set_agent_visual(name, **config)
 
+# Special nodes
+n1 = ctx.graph.graph.get_node(0)
+n2 = ctx.graph.graph.get_node(1)
+data = {}
+data['x'] = n1.x
+data['y'] = n1.y
+data['scale'] = 10.0
+data['color'] = (0.0, 0.0, 0.0, 0.3)
 
+ctx.visual.add_artist('special_node', data)
 
-
-# turn_count = 0
-# # Rules for the game
-# def rule_terminate(ctx):
-#     if turn_count > 100:
-#         ctx.terminate()
-#         return True
-#     return False
+turn_count = 0
+# Rules for the game
+def rule_terminate(ctx):
+    global turn_count
+    turn_count += 1
+    if turn_count > 100:
+        ctx.terminate()
 
 def agent_reset(ctx):
     blue_agent_pos = {}
@@ -97,8 +105,13 @@ while not ctx.is_terminated():
 
     #valid_step(ctx)
     #agent_reset(ctx)
-    
+    if turn_count % 2 == 0:
+        data['x'] = n1.x
+        data['y'] = n1.y
+    else:
+        data['x'] = n2.x
+        data['y'] = n2.y
     ctx.visual.simulate()
 
     # ctx.save_frame()
-    # rule_terminate(ctx)
+    rule_terminate(ctx)

--- a/examples/base/game.py
+++ b/examples/base/game.py
@@ -60,7 +60,7 @@ data = {}
 data['x'] = n1.x
 data['y'] = n1.y
 data['scale'] = 10.0
-data['color'] = (0.0, 0.0, 0.0, 0.3)
+data['color'] = (255, 0, 0)
 
 ctx.visual.add_artist('special_node', data)
 

--- a/gamms/VisualizationEngine/graph_visual.py
+++ b/gamms/VisualizationEngine/graph_visual.py
@@ -32,8 +32,6 @@ class GraphVisual:
 
     def ScalePositionToScreen(self, position: tuple[float, float]) -> tuple[float, float]:
         """Scale a coordinate value to fit within the screen."""
-        current_size = pygame.display.get_window_size()
-
         graph_center = self.GraphCenter()
         # Graph comes in the form of KM. Need to convert the KM to scale for M. One unit = 1m
         screen_scale = 111139 / 100

--- a/gamms/VisualizationEngine/no_engine.py
+++ b/gamms/VisualizationEngine/no_engine.py
@@ -13,6 +13,12 @@ class NoEngine(IVisualizationEngine):
     def set_agent_visual(self, agent_name: str, **kwargs):
         return
     
+    def add_artist(self, name:str, data: Dict[str, Any]):
+        return
+    
+    def remove_artist(self, name: str):
+        return
+
     def simulate(self):
         return
     

--- a/gamms/typing/visualization_engine.py
+++ b/gamms/typing/visualization_engine.py
@@ -61,118 +61,33 @@ class IVisualizationEngine(ABC):
         pass
 
     @abstractmethod
-    def simulate(self) -> None:
+    def add_artist(self, name: str, data: Dict[str, Any]) -> None:
         """
-        Execute a simulation step to update the visualization.
+        Add a custom artist or object to the visualization.
 
-        This method advances the simulation by one step, updating the positions,
-        states, and visual representations of the graph and agents. It should be
-        called repeatedly within a loop to animate the visualization in real-time.
-
-        Raises:
-            RuntimeError: If the simulation cannot be advanced due to internal errors.
-            ValueError: If the simulation parameters are invalid or inconsistent.
-        """
-        pass
-
-    @abstractmethod
-    def human_input(self, state: Dict[str, Any]) -> None:
-        """
-        Process input from a human player or user.
-
-        This method handles input data provided by a human user, allowing for
-        interactive control or modification of the visualization. It can be used
-        to receive commands, adjust settings, or influence the simulation based
-        on user actions.
+        This method adds a custom artist or object to the visualization, allowing
+        for additional elements to be displayed alongside the graph and agents.
+        The artist can be used to render custom shapes, text, images, or other
+        visual components within the visualization.
 
         Args:
-            state (Dict[str, Any]): A dictionary containing the current state of
-                the system or the input data from the user. Expected keys may include:
-                - `command` (str): The command issued by the user.
-                - `parameters` (Dict[str, Any]): Additional parameters related to the command.
-                - Other state-related information as needed.
-
-        Raises:
-            ValueError: If the input `state` contains invalid or unsupported commands.
-            KeyError: If required keys are missing from the `state` dictionary.
-            TypeError: If the types of the provided input data do not match expected types.
+            name (str): The unique name identifier for the custom artist.
+            data (Dict[str, Any]): A dictionary containing the data and settings
+                for the custom artist. The structure of the data may vary based
+                on the type of artist being added.
         """
         pass
 
     @abstractmethod
-    def terminate(self) -> None:
+    def remove_artist(self, name: str) -> None:
         """
-        Terminate the visualization engine and clean up resources.
+        Remove a custom artist or object from the visualization.
 
-        This method is called when the simulation or application is exiting.
-        It should handle the graceful shutdown of the visualization engine,
-        ensuring that all resources are properly released and that the display
-        is correctly closed.
-
-        Raises:
-            RuntimeError: If the engine fails to terminate gracefully.
-            IOError: If there are issues during the cleanup process.
-        """
-        pass
-from typing import Dict, Any
-from abc import ABC, abstractmethod
-
-
-class IVisualizationEngine(ABC):
-    """
-    Abstract base class representing a visualization engine.
-
-    The visualization engine is responsible for rendering the graph and agents,
-    handling simulation updates, processing human inputs, and managing the
-    overall visualization lifecycle.
-    """
-
-    @abstractmethod
-    def set_graph_visual(self, **kwargs) -> None:
-        """
-        Configure the visual representation of the graph.
-
-        This method sets up visual parameters such as colors, sizes, layouts,
-        and other graphical attributes for the entire graph. It allows customization
-        of how the graph is displayed to the user.
+        This method removes a custom artist or object from the visualization,
+        effectively hiding or deleting the element from the display.
 
         Args:
-            **kwargs: Arbitrary keyword arguments representing visual settings.
-                Possible keys include:
-                - `color_scheme` (str): The color scheme to use for nodes and edges.
-                - `layout` (str): The layout algorithm for positioning nodes.
-                - `node_size` (float): The size of the graph nodes.
-                - `edge_width` (float): The width of the graph edges.
-                - Additional visual parameters as needed.
-
-        Raises:
-            ValueError: If any of the provided visual settings are invalid.
-            TypeError: If the types of the provided settings do not match expected types.
-        """
-        pass
-
-    @abstractmethod
-    def set_agent_visual(self, agent_name: str, **kwargs) -> None:
-        """
-        Configure the visual representation of a specific agent.
-
-        This method sets up visual parameters for an individual agent, allowing
-        customization of how the agent is displayed within the visualization.
-
-        Args:
-            agent_name (str): The unique name identifier of the agent to configure.
-            **kwargs: Arbitrary keyword arguments representing visual settings.
-                Possible keys include:
-                - `color` (str): The color to represent the agent.
-                - `shape` (str): The shape to use for the agent's representation.
-                - `size` (float): The size of the agent in the visualization.
-                - `icon` (str): Path to an icon image to represent the agent.
-                - Additional visual parameters as needed.
-
-        Raises:
-            KeyError: If no agent with the specified `agent_name` exists.
-            ValueError: If any of the provided visual settings are invalid.
-            TypeError: If the types of the provided settings do not match expected types.
+            name (str): The unique name identifier of the custom artist to remove.
         """
         pass
 


### PR DESCRIPTION
This is a quick patch for allowing drawing circles. The API for drawing circles won't change as it is the default action that any artist addition will  fallback to when general artist API is developed. Artist API will always have two methods of the form:

```python
def add_artist(self, name: str, data: Dict[str, Any]) -> None:
    pass
def remove_artist(self, name:str) -> None:
    pass
```
Other kwargs can be added later down the line but any calls of the above format should not fail -- only exception will be in cases when the data entry contains stuff beyond generics like tuples and list.