### PR TITLE
Latlon to UTM

### DIFF
--- a/examples/base/config.py
+++ b/examples/base/config.py
@@ -7,7 +7,7 @@ vis_engine = gamms.visual.Engine.PYGAME
 
 # The path to the graph file
 location = "West Point, New York, USA"
-resolution = 100.0
+resolution = 10.0
 graph_path = 'graph.pkl'
 
 # Sensor configuration

--- a/gamms/VisualizationEngine/graph_visual.py
+++ b/gamms/VisualizationEngine/graph_visual.py
@@ -29,16 +29,13 @@ class GraphVisual:
     
     def setCamera(self, camera):
         self.camera = camera
+        camera.size = max(self.x_max - self.x_min, self.y_max - self.y_min)
 
     def ScalePositionToScreen(self, position: tuple[float, float]) -> tuple[float, float]:
         """Scale a coordinate value to fit within the screen."""
         graph_center = self.GraphCenter()
-        # Graph comes in the form of KM. Need to convert the KM to scale for M. One unit = 1m
-        screen_scale = 111139 / 100
-
-        map_position = (screen_scale * (position[0] - graph_center[0]),screen_scale * (position[1] - graph_center[1]))
+        map_position = ((position[0] - graph_center[0]),(position[1] - graph_center[1]))
         map_position = self.camera.world_to_screen(map_position[0] + self.camera.x, map_position[1] + self.camera.y)
-        #map_position = (map_position[0] + self.offset[0], map_position[1] + self.offset[1])
         return map_position
 
     def draw_node(self, screen, node, color=(173, 255, 47)):
@@ -51,9 +48,7 @@ class GraphVisual:
         """Draw an edge as a curve or straight line based on the linestring."""
         source = self.graph.nodes[edge.source]
         target = self.graph.nodes[edge.target]
-        # for x,y in edge.linestring.coords:
-        #     print("Linestring: ",x,y)
-        
+
         # If linestring is present, draw it as a curve
         if edge.linestring:
             #linestring[1:-1]

--- a/gamms/VisualizationEngine/pygame_engine.py
+++ b/gamms/VisualizationEngine/pygame_engine.py
@@ -79,20 +79,20 @@ class PygameVisualizationEngine(IVisualizationEngine):
             pressed_keys = pygame.key.get_pressed()
             # Multi key Event
             if pressed_keys[pygame.K_a] and pressed_keys[pygame.K_w]:
-                self._camera.x += 1
-                self._camera.y += -1
+                self._camera.x += self._camera.size / 100
+                self._camera.y += -self._camera.size / 100
                 return
             if pressed_keys[pygame.K_a] and pressed_keys[pygame.K_s]:
-                self._camera.x += 1
-                self._camera.y += 1
+                self._camera.x += self._camera.size / 100
+                self._camera.y += self._camera.size / 100
                 return
             if pressed_keys[pygame.K_s] and pressed_keys[pygame.K_d]:
-                self._camera.x += -1
-                self._camera.y += 1
+                self._camera.x += -self._camera.size / 100
+                self._camera.y += self._camera.size / 100
                 return
             if pressed_keys[pygame.K_d] and pressed_keys[pygame.K_w]:
-                self._camera.x += -1
-                self._camera.y += -1
+                self._camera.x += -self._camera.size / 100
+                self._camera.y += -self._camera.size / 100
                 return
             if pressed_keys[pygame.K_a] and pressed_keys[pygame.K_d]:
                 return
@@ -101,20 +101,20 @@ class PygameVisualizationEngine(IVisualizationEngine):
             
             # Single Input Event
             if pressed_keys[pygame.K_a]:
-                self._camera.x += 1
+                self._camera.x += self._camera.size / 100
                 self._camera.y += 0
                 return
             if pressed_keys[pygame.K_s]:
                 self._camera.x += 0
-                self._camera.y += 1
+                self._camera.y += self._camera.size / 100
                 return
             if pressed_keys[pygame.K_d]:
-                self._camera.x += -1
+                self._camera.x += -self._camera.size / 100
                 self._camera.y += 0
                 return
             if pressed_keys[pygame.K_w]:
                 self._camera.x += 0
-                self._camera.y += -1
+                self._camera.y += -self._camera.size / 100
                 return
             if event.type == pygame.MOUSEWHEEL:
                 if event.y > 0:
@@ -157,7 +157,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         self._screen.fill(Color.White)
 
         # Note: Draw in layer order of back layer -> front layer
-        self._draw_grid()
+        # self._draw_grid()
         self._graph_visual.draw_graph(self._screen)
         self.draw_agents()
         for artist in self._artists.values():
@@ -250,7 +250,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         x_max = self._camera.x + self._camera.size * 4
         y_min = self._camera.y - self._camera.size_y * 4
         y_max = self._camera.y + self._camera.size_y * 4
-        step = 1
+        step = int(self._camera.size / 100)
         for x in range(int(x_min), int(x_max) + 1, step):
             self.render_line(x, y_min, x, y_max, Color.LightGray, 3 if x % 5 == 0 else 1, False)
 

--- a/gamms/osm.py
+++ b/gamms/osm.py
@@ -45,8 +45,7 @@ def create_osm_graph(
     
     osmg = ox.project_graph(osmg)
     osmg = ox.consolidate_intersections(osmg, tolerance=tolerance, rebuild_graph=True, dead_ends=True)
-    osmg = ox.project_graph(osmg, to_latlong=True)
-    #ox.plot_graph(osmg)
+    osmg = ox.project_graph(osmg, to_latlong=False)
     # Process line strings to add extra nodes and edges
     ret = nx.MultiDiGraph()
     edges = osmg.edges(data=True)


### PR DESCRIPTION
Use utm for osm map so that everything is in meters.

Changes in visualization to remove scaling and make scaling a function of camera size. Turned off grid-draw as it messes up.

Changed base map resolution to 10 meters in the example as 10 meter  resolution is expected.

Notes: There is enough delay in drawing when using a high resolution map. @minoumao @Brian-Jiang, is it easy to add conditions to draw only things that are in the viewport? Maybe we can do a quick merge with main so that people do not face issues with latlon conversions.