### PR TITLE
Node id draw and node-edge color config with sim time control

### DIFF
--- a/gamms/VisualizationEngine/__init__.py
+++ b/gamms/VisualizationEngine/__init__.py
@@ -9,6 +9,7 @@ class Color:
     Black = (0, 0, 0)
     Red = (255, 0, 0)
     Green = (0, 255, 0)
+    LightGreen = (144, 238, 144)
     Blue = (0, 0, 255)
     Yellow = (255, 255, 0)
     Cyan = (0, 255, 255)

--- a/gamms/VisualizationEngine/graph_visual.py
+++ b/gamms/VisualizationEngine/graph_visual.py
@@ -1,14 +1,16 @@
 import pygame
 
-
 class GraphVisual:
-    def __init__(self, graph, width=1980, height=1080):
+    def __init__(self, graph, width=1980, height=1080, draw_id=False, node_color=None, edge_color=None):
         self.graph = graph
         self.width = width
         self.height = height
         self.screen = None
         self.screen = None
         self.zoom = 1
+        self.draw_id = draw_id
+        self.node_color = node_color
+        self.edge_color = edge_color
         # Find the min and max x, y coordinates for scaling
         self.x_min = min(node.x for node in self.graph.nodes.values())
         self.x_max = max(node.x for node in self.graph.nodes.values())
@@ -38,15 +40,27 @@ class GraphVisual:
         map_position = self.camera.world_to_screen(map_position[0] + self.camera.x, map_position[1] + self.camera.y)
         return map_position
 
-    def draw_node(self, screen, node, color=(173, 255, 47)):
+    def draw_node(self, screen, node, color=None):
         # """Draw a node as a circle with a light greenish color."""
+        if color is None:
+            color = self.node_color
+
         position = (node.x, node.y)
         (x, y) = self.ScalePositionToScreen(position)
         if self.is_map_point_viewable((x, y)):
             pygame.draw.circle(screen, color, (int(x), int(y)), 4)  # Light greenish color
+            # Draw node ID if draw_id is True
+            if self.draw_id:
+                font = pygame.font.Font(None, 40)
+                text = font.render(str(node.id), True, (0, 0, 0))
+                text_rect = text.get_rect(center=(int(x), int(y) + 10))
+                screen.blit(text, text_rect)
 
-    def draw_edge(self, screen, edge):
+    def draw_edge(self, screen, edge, color=None):
         """Draw an edge as a curve or straight line based on the linestring."""
+        if color is None:
+            color = self.edge_color
+
         source = self.graph.nodes[edge.source]
         target = self.graph.nodes[edge.target]
 
@@ -62,14 +76,14 @@ class GraphVisual:
                     (self.ScalePositionToScreen((x, y)))
                     for x, y in linestring
                 ]
-                pygame.draw.aalines(screen, (0, 0, 0), False, scaled_points, 2)
+                pygame.draw.aalines(screen, color, False, scaled_points, 2)
             else:
                 # Straight line
                 source_position = (source.x, source.y)
                 target_position = (target.x, target.y)
                 (x1, y1) = self.ScalePositionToScreen(source_position)
                 (x2, y2) = self.ScalePositionToScreen(target_position)
-                pygame.draw.line(screen, (0, 0, 0), (int(x1), int(y1)), (int(x2), int(y2)), 2)
+                pygame.draw.line(screen, color, (int(x1), int(y1)), (int(x2), int(y2)), 2)
 
     def MoveGraphPosition(self, direction: tuple[float, float]):
         self.offset = (self.offset[0] + direction[0], self.offset[1] + direction[1])

--- a/gamms/VisualizationEngine/no_engine.py
+++ b/gamms/VisualizationEngine/no_engine.py
@@ -4,7 +4,7 @@ from gamms.context import Context
 from typing import Dict, Any
 
 class NoEngine(IVisualizationEngine):
-    def __init__(self, ctx: Context):
+    def __init__(self, ctx: Context, **kwargs):
         self.ctx = ctx
     
     def set_graph_visual(self, **kwargs):

--- a/gamms/VisualizationEngine/pygame_engine.py
+++ b/gamms/VisualizationEngine/pygame_engine.py
@@ -19,7 +19,7 @@ def _circle_artist(ctx, data):
     pygame.draw.circle(ctx.visual._screen, color, (x,y), scale)
 
 class PygameVisualizationEngine(IVisualizationEngine):
-    def __init__(self, ctx, tick_callback = None, width=1980, height=1080, simulation_time_constant=2.0):
+    def __init__(self, ctx, tick_callback = None, width=1980, height=1080, simulation_time_constant=2.0, **kwargs):
         pygame.init()
         self.ctx: Context = ctx
         self._width = width
@@ -50,7 +50,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         return self._height    
     
     def set_graph_visual(self, **kwargs):
-        self._graph_visual = GraphVisual(self.ctx.graph.graph, kwargs['width'], kwargs['height'])
+        self._graph_visual = GraphVisual(self.ctx.graph.graph, kwargs['width'], kwargs['height'], kwargs.get('draw_id', False), kwargs.get('node_color', Color.LightGreen), kwargs.get('edge_color', Color.Black))
         self._graph_visual.setCamera(self._camera)
 
         print("Successfully set graph visual")

--- a/gamms/__init__.py
+++ b/gamms/__init__.py
@@ -7,12 +7,15 @@ from enum import Enum
 
 def create_context(
     vis_engine: Enum = visual.Engine.NO_VIS,
+    vis_kwargs: dict = None,
 ) -> Context:
     ctx = Context()
+    if vis_kwargs is None:
+        vis_kwargs = {}
     if vis_engine == visual.Engine.NO_VIS:
-        visual_engine = visual.no_engine.NoEngine(ctx)
+        visual_engine = visual.no_engine.NoEngine(ctx, **vis_kwargs)
     elif vis_engine == visual.Engine.PYGAME:
-        visual_engine = visual.pygame_engine.PygameVisualizationEngine(ctx)
+        visual_engine = visual.pygame_engine.PygameVisualizationEngine(ctx, **vis_kwargs)
     else:
         raise NotImplementedError(f"Visualization engine {vis_engine} not implemented")
     


### PR DESCRIPTION
This PR extends temporarily the pygame visualization engine to:

- Draw node ids : `draw_id` boolean flag in graph visual config
- Custom node color: `node_color Tuple[int, int, int]` as part of graph visual config
- Custom edge color: `edge_color Tuple[int, int, int]` as part of graph visual config
- Allow kwarg passing for visualization engine while creating context. Use it to control default config like simulation speed.