### PR TITLE
Graph api correction with typing refactor and cbor transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Package dependecies:
 - pygame
 - shapely
 - networkx
-- py-ubjson
+- cbor2
 - aenum
 
 ## Installation

--- a/examples/base/create_graph.py
+++ b/examples/base/create_graph.py
@@ -1,5 +1,5 @@
 from config import location, graph_path, resolution
-import gamms
+import gamms, gamms.osm
 import pickle
 # Create a graph
 

--- a/examples/base/game.py
+++ b/examples/base/game.py
@@ -1,4 +1,4 @@
-import gamms, gamms.osm
+import gamms
 from gamms.VisualizationEngine.artist import Artist
 from gamms.VisualizationEngine.default_drawers import render_circle
 from gamms.VisualizationEngine import Color

--- a/examples/base/game.py
+++ b/examples/base/game.py
@@ -1,4 +1,4 @@
-import gamms
+import gamms, gamms.osm
 from gamms.VisualizationEngine.artist import Artist
 from gamms.VisualizationEngine.default_drawers import render_circle
 from gamms.VisualizationEngine import Color

--- a/examples/base/replay.py
+++ b/examples/base/replay.py
@@ -1,6 +1,5 @@
 import pickle 
 import gamms
-from gamms.recorder import _record_switch_case
 from config import (
     vis_engine,
     graph_path,

--- a/gamms/Recorder/component.py
+++ b/gamms/Recorder/component.py
@@ -1,7 +1,9 @@
-from typing import Tuple, Optional, Union, Type, TypeVar, Dict, Callable
+from typing import Optional, Type, TypeVar, Dict, Callable, Union, Tuple
 
 from gamms.typing import IContext
 from gamms.typing.opcodes import OpCodes
+
+from typing import get_origin
 
 _T = TypeVar('_T')
 
@@ -20,17 +22,17 @@ def check_validity(
         raise TypeError(f'Data type {data_type} must be an immutable python type hint')
     elif data_type.__module__ != 'typing':
         raise TypeError(f'Data type {data_type} must be an immutable python type hint')
-    elif data_type.__name__ == 'Optional':
+    elif get_origin(data_type) == Optional:
         if not hasattr(data_type, '__args__'):
             raise TypeError('Optional must have a type hint')
         for arg in data_type.__args__:
             check_validity(arg)
-    elif data_type.__name__ == 'Union':
+    elif get_origin(data_type) == Union:
         if not hasattr(data_type, '__args__'):
             raise TypeError('Union must have a type hint')
         for arg in data_type.__args__:
             check_validity(arg)
-    elif data_type.__name__ == 'Tuple':
+    elif get_origin(data_type) == Tuple:
         if not hasattr(data_type, '__args__'):
             raise TypeError('Tuple must have a type hint')
         for arg in data_type.__args__:

--- a/gamms/SensorEngine/sensor_engine.py
+++ b/gamms/SensorEngine/sensor_engine.py
@@ -1,22 +1,19 @@
-import gamms.typing
 from gamms.typing import(
     IContext,
     ISensor,
     ISensorEngine,
     SensorType,
-    OpCodes,
+    Node,
+    OSMEdge,
 )
 
-from typing import Any, Dict, Optional, Type, TypeVar, Callable, Tuple
+from typing import Any, Dict, Optional, Callable, Tuple, List, Union, cast
 from aenum import extend_enum
 import math
 import numpy as np
 
-_T = TypeVar('_T')
-
-
 class NeighborSensor(ISensor):
-    def __init__(self, ctx, sensor_id, sensor_type):
+    def __init__(self, ctx: IContext, sensor_id: str, sensor_type: SensorType):
         self._sensor_id = sensor_id
         self.ctx = ctx
         self._type = sensor_type
@@ -35,12 +32,13 @@ class NeighborSensor(ISensor):
     def data(self):
         return self._data
     
-    def set_owner(self, owner: str) -> None:
+    def set_owner(self, owner: Union[str, None]) -> None:
         self._owner = owner
 
     def sense(self, node_id: int) -> None:
         nearest_neighbors = {node_id,}
-        for edge in self.ctx.graph.graph.edges.values():
+        for edge_id in self.ctx.graph.graph.get_edges():
+            edge = self.ctx.graph.graph.get_edge(edge_id)
             if edge.source == node_id:
                 nearest_neighbors.add(edge.target)
                         
@@ -50,7 +48,7 @@ class NeighborSensor(ISensor):
         pass
 
 class MapSensor(ISensor):
-    def __init__(self, ctx, sensor_id, sensor_type, sensor_range: float, fov: float, orientation: Tuple[float, float] = (1.0, 0.0)):
+    def __init__(self, ctx: IContext, sensor_id: str, sensor_type: SensorType, sensor_range: float, fov: float, orientation: Tuple[float, float] = (1.0, 0.0)):
         """
         Acts as a map sensor (if sensor_range == inf),
         a range sensor (if fov == 2*pi),
@@ -60,15 +58,15 @@ class MapSensor(ISensor):
         self.ctx = ctx
         self._sensor_id = sensor_id
         self._type = sensor_type
-        self.nodes = self.ctx.graph.graph.nodes
         self.range = sensor_range
         self.fov = fov  
         norm = math.sqrt(orientation[0]**2 + orientation[1]**2)
         self.orientation = (orientation[0] / norm, orientation[1] / norm)
-        self._data = {}
+        self._data: Dict[str, Union[Dict[int, Node], List[OSMEdge]]] = {}
         # Cache static node IDs and positions.
-        self.node_ids = list(self.nodes.keys())
-        self._positions = np.array([[self.nodes[nid].x, self.nodes[nid].y] for nid in self.node_ids])
+        self.nodes = cast(Dict[int, Node], self.ctx.graph.graph.nodes)
+        self.node_ids: List[int] = list(self.nodes.keys())
+        self._positions = np.array([[self.nodes[nid].x, self.nodes[nid].y] for nid in self.node_ids], dtype=np.float32)
         self._owner = None
     
     @property
@@ -80,14 +78,14 @@ class MapSensor(ISensor):
         return self._type
 
     @property
-    def data(self) -> Dict[str, Any]:
+    def data(self) -> Dict[str, Union[Dict[int, Node],List[OSMEdge]]]:
         return self._data
     
-    def set_owner(self, owner: str) -> None:
+    def set_owner(self, owner: Union[str, None]) -> None:
         self._owner = owner
 
     def sense(self, node_id: int) -> None:
-        """
+        """ Dict[int, 
         Detects nodes within the sensor range and arc.
         
         The result is now stored in self._data as a dictionary with two keys:
@@ -115,7 +113,7 @@ class MapSensor(ISensor):
             in_range_mask = distances_sq <= self.range**2
         in_range_indices = np.nonzero(in_range_mask)[0]
 
-        sensed_nodes = {}
+        sensed_nodes: Dict[int, Node] = {}
         if in_range_indices.size:
             if self.fov == 2 * math.pi or orientation_used == (0.0, 0.0):
                 valid_indices = in_range_indices
@@ -131,9 +129,9 @@ class MapSensor(ISensor):
         sensed_nodes[node_id] = current_node
 
         # Now, compute the connecting edges from the sensing node to each sensed node.
-        sensed_edges = []
+        sensed_edges: List[OSMEdge] = []
         # Retrieve edges from the graph via the context's graph engine.
-        graph_edges = self.ctx.graph.graph.edges
+        graph_edges = cast(Dict[int, OSMEdge], self.ctx.graph.graph.edges)
         for edge in graph_edges.values():
             if edge.source in sensed_nodes and edge.target in sensed_nodes:
                 sensed_edges.append(edge)
@@ -147,12 +145,12 @@ class MapSensor(ISensor):
 class AgentSensor(ISensor):
     def __init__(
         self, 
-        ctx, 
-        sensor_id, 
-        sensor_type, 
+        ctx: IContext, 
+        sensor_id: str, 
+        sensor_type: SensorType, 
         sensor_range: float, 
         fov: float = 2 * math.pi, 
-        orientation: float = (1.0, 0.0), 
+        orientation: Tuple[float, float] = (1.0, 0.0), 
         owner: Optional[str] = None
     ):
         """
@@ -171,7 +169,7 @@ class AgentSensor(ISensor):
         self.fov = fov              
         self.orientation = orientation  
         self._owner = owner
-        self._data = {}
+        self._data: Dict[str, int] = {}
     
 
     @property
@@ -183,10 +181,10 @@ class AgentSensor(ISensor):
         return self._type
 
     @property
-    def data(self) -> Dict[str, Any]:
+    def data(self) -> Dict[str, int]:
         return self._data
 
-    def set_owner(self, owner: str) -> None:
+    def set_owner(self, owner: Union[str, None]) -> None:
         self._owner = owner
         
     def sense(self, node_id: int) -> None:
@@ -206,7 +204,7 @@ class AgentSensor(ISensor):
 
         agents = list(self.ctx.agent.create_iter())
         sensed_agents = {}
-        agent_ids = []
+        agent_ids: List[str] = []
         agent_positions = []
 
         # Collect positions and ids for all agents except the owner.
@@ -265,9 +263,9 @@ class AgentSensor(ISensor):
 class SensorEngine(ISensorEngine):
     def __init__(self, ctx: IContext):
         self.ctx = ctx  
-        self.sensors = {}
+        self.sensors: Dict[str, ISensor] = {}
 
-    def create_sensor(self, sensor_id, sensor_type: SensorType, **kwargs):
+    def create_sensor(self, sensor_id: str, sensor_type: SensorType, **kwargs: Dict[str, Any]) -> ISensor:
         if sensor_type == SensorType.NEIGHBOR:
             sensor = NeighborSensor(
                 self.ctx, sensor_id, sensor_type, 
@@ -285,7 +283,7 @@ class SensorEngine(ISensorEngine):
                 self.ctx, 
                 sensor_id, 
                 sensor_type, 
-                sensor_range=kwargs.get('sensor_range', 30),
+                sensor_range=cast(float, kwargs.get('sensor_range', 30.0)),
                 fov=(2 * math.pi),
             )
         elif sensor_type == SensorType.ARC:
@@ -293,8 +291,8 @@ class SensorEngine(ISensorEngine):
                 self.ctx, 
                 sensor_id, 
                 sensor_type, 
-                sensor_range=kwargs.get('sensor_range', 30),
-                fov=kwargs.get('fov', 2 * math.pi),
+                sensor_range=cast(float, kwargs.get('sensor_range', 30.0)),
+                fov=cast(float, kwargs.get('fov', 2 * math.pi)),
             )
         elif sensor_type == SensorType.AGENT:
             sensor = AgentSensor(
@@ -302,22 +300,22 @@ class SensorEngine(ISensorEngine):
                 sensor_id, 
                 sensor_type, 
                 sensor_range=float('inf'),
-                fov=kwargs.get('fov', 2 * math.pi),
+                fov=cast(float, kwargs.get('fov', 2 * math.pi)),
             )
         elif sensor_type == SensorType.AGENT_ARC:
             sensor = AgentSensor(
                 self.ctx, 
                 sensor_id, 
                 sensor_type, 
-                sensor_range=kwargs.get('sensor_range', 30),
-                fov=kwargs.get('fov', math.radians(90)), 
+                sensor_range=cast(float, kwargs.get('sensor_range', 30.0)),
+                fov=cast(float, kwargs.get('fov', 2 * math.pi)), 
             )
         elif sensor_type == SensorType.AGENT_RANGE:
             sensor = AgentSensor(
                 self.ctx, 
                 sensor_id, 
                 sensor_type, 
-                sensor_range=kwargs.get('sensor_range', 30),
+                sensor_range=cast(float, kwargs.get('sensor_range', 30.0)),
                 fov=2 * math.pi,
             )
         else:
@@ -331,18 +329,18 @@ class SensorEngine(ISensorEngine):
             raise ValueError(f"Sensor {sensor_id} already exists.")
         self.sensors[sensor_id] = sensor
 
-    def get_sensor(self, sensor_id):
+    def get_sensor(self, sensor_id: str) -> ISensor:
         try:
             return self.sensors[sensor_id]
         except KeyError:
             raise KeyError(f"Sensor {sensor_id} not found.")
 
-    def custom(self, name: str) -> Callable[[Type[_T]], Type[_T]]:
+    def custom(self, name: str) -> Callable[[ISensor], ISensor]:
         if hasattr(SensorType, name):
             raise ValueError(f"SensorType {name} already exists.")
         extend_enum(SensorType, name, len(SensorType))
         val = getattr(SensorType, name)
-        def decorator(cls_type: Type[_T]) -> Type[_T]:
+        def decorator(cls_type: ISensor) -> ISensor:
             cls_type.type = property(lambda obj: val)
             return cls_type
         return decorator

--- a/gamms/SensorEngine/sensor_engine.py
+++ b/gamms/SensorEngine/sensor_engine.py
@@ -85,7 +85,7 @@ class MapSensor(ISensor):
         self._owner = owner
 
     def sense(self, node_id: int) -> None:
-        """ Dict[int, 
+        """
         Detects nodes within the sensor range and arc.
         
         The result is now stored in self._data as a dictionary with two keys:

--- a/gamms/VisualizationEngine/__init__.py
+++ b/gamms/VisualizationEngine/__init__.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum, auto, IntEnum
 
 class Engine(Enum):
     NO_VIS = 0
@@ -21,7 +21,7 @@ class Color:
     Purple = (128, 0, 128)
 
 
-class Space:
+class Space(IntEnum):
     World = 0
     Screen = 1
     Viewport = 2
@@ -31,11 +31,10 @@ class Shape(Enum):
     Circle = auto()
     Rectangle = auto()
 
-
 import sys
 import importlib.util
 
-def lazy(fullname):
+def lazy(fullname: str):
   try:
     return sys.modules[fullname]
   except KeyError:

--- a/gamms/VisualizationEngine/artist.py
+++ b/gamms/VisualizationEngine/artist.py
@@ -1,10 +1,10 @@
 from gamms.typing import IArtist, ArtistType, IContext
 from gamms.VisualizationEngine.default_drawers import render_circle, render_rectangle
 from gamms.VisualizationEngine import Shape
-from typing import Callable, Union
+from typing import Callable, Union, Dict, Any
 
 class Artist(IArtist):
-    def __init__(self, ctx: IContext, drawer: Union[Callable, Shape], layer: int = 30):
+    def __init__(self, ctx: IContext, drawer: Union[Callable[[IContext, Dict[str, Any]], None], Shape], layer: int = 30):
         self.data = {}
 
         self._ctx = ctx
@@ -26,8 +26,12 @@ class Artist(IArtist):
     @property
     def layer_dirty(self):
         return self._layer_dirty
+    
+    @layer_dirty.setter
+    def layer_dirty(self, value: bool):
+        self._layer_dirty = value
 
-    def set_layer(self, layer):
+    def set_layer(self, layer: int):
         if self._layer == layer:
             return
 
@@ -37,13 +41,13 @@ class Artist(IArtist):
     def get_layer(self):
         return self._layer
 
-    def set_visible(self, visible):
+    def set_visible(self, visible: bool):
         self._visible = visible
 
     def get_visible(self):
         return self._visible
 
-    def set_drawer(self, drawer):
+    def set_drawer(self, drawer: Callable[[IContext, Dict[str, Any]], None]):
         self._drawer = drawer
 
     def get_drawer(self):
@@ -52,13 +56,13 @@ class Artist(IArtist):
     def get_will_draw(self):
         return self._will_draw
 
-    def set_will_draw(self, will_draw):
+    def set_will_draw(self, will_draw: bool):
         self._will_draw = will_draw
 
     def get_artist_type(self):
         return self._artist_type
 
-    def set_artist_type(self, artist_type):
+    def set_artist_type(self, artist_type: ArtistType):
         self._artist_type = artist_type
 
     def draw(self):
@@ -66,3 +70,4 @@ class Artist(IArtist):
             self._drawer(self._ctx, self.data)
         except Exception as e:
             self._ctx.logger.error(f"Error drawing artist: {e}")
+            self._ctx.logger.debug(f"Artist data: {self.data}")

--- a/gamms/VisualizationEngine/artist.py
+++ b/gamms/VisualizationEngine/artist.py
@@ -24,7 +24,7 @@ class Artist(IArtist):
             self._drawer = drawer
 
     @property
-    def layer_dirty(self):
+    def layer_dirty(self) -> bool:
         return self._layer_dirty
     
     @layer_dirty.setter
@@ -38,28 +38,28 @@ class Artist(IArtist):
         self._layer = layer
         self._layer_dirty = True
 
-    def get_layer(self):
+    def get_layer(self) -> int:
         return self._layer
 
     def set_visible(self, visible: bool):
         self._visible = visible
 
-    def get_visible(self):
+    def get_visible(self) -> bool:
         return self._visible
 
     def set_drawer(self, drawer: Callable[[IContext, Dict[str, Any]], None]):
         self._drawer = drawer
 
-    def get_drawer(self):
+    def get_drawer(self) -> Callable[[IContext, Dict[str, Any]], None]:
         return self._drawer
 
-    def get_will_draw(self):
+    def get_will_draw(self) -> bool:
         return self._will_draw
 
     def set_will_draw(self, will_draw: bool):
         self._will_draw = will_draw
 
-    def get_artist_type(self):
+    def get_artist_type(self) -> ArtistType:
         return self._artist_type
 
     def set_artist_type(self, artist_type: ArtistType):

--- a/gamms/VisualizationEngine/builtin_artists.py
+++ b/gamms/VisualizationEngine/builtin_artists.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 
-from typing import Tuple, Union, List, Dict, Optional
+from typing import Tuple, List, Dict, Optional
+
+from gamms.typing import ColorType
 
 @dataclass
 class Circle:
@@ -41,12 +43,12 @@ class AgentData:
 
     Attributes:
         name (str): The name of the agent.
-        color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the agent.
+        color (ColorType): The color of the agent.
         size (float): The size of the agent.
         current_position (Optional[Tuple[float, float]]): The current position of the agent.
     """
     name: str
-    color: Tuple[Union[int, float], Union[int, float], Union[int, float]]
+    color: ColorType
     size: float
     current_position: Optional[Tuple[float, float]] = field(default=None, init=False)
 
@@ -57,12 +59,12 @@ class GraphData:
     Contains all necessary data for drawing a graph
 
     Attributes:
-        node_color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the nodes in the graph.
-        edge_color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the edges in the graph.
+        node_color (ColorType): The color of the nodes in the graph.
+        edge_color (ColorType): The color of the edges in the graph.
         draw_id (bool): Whether to draw the node IDs.
     """
-    node_color: Tuple[Union[int, float], Union[int, float], Union[int, float]]
+    node_color: ColorType
     node_size: float
-    edge_color: Tuple[Union[int, float], Union[int, float], Union[int, float]]
+    edge_color: ColorType
     draw_id: bool
     edge_line_points: Dict[int, List[Tuple[float, float]]] = field(default_factory=dict)

--- a/gamms/VisualizationEngine/builtin_artists.py
+++ b/gamms/VisualizationEngine/builtin_artists.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 
-from gamms.typing.graph_engine import IGraph
-
+from typing import Tuple, Union, List, Dict, Optional
 
 @dataclass
 class Circle:
@@ -42,14 +41,14 @@ class AgentData:
 
     Attributes:
         name (str): The name of the agent.
-        color (tuple): The color of the agent.
+        color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the agent.
         size (float): The size of the agent.
-        current_position (tuple): The current position of the agent.
+        current_position (Optional[Tuple[float, float]]): The current position of the agent.
     """
     name: str
-    color: tuple
+    color: Tuple[Union[int, float], Union[int, float], Union[int, float]]
     size: float
-    current_position: tuple = field(default=None, init=False)
+    current_position: Optional[Tuple[float, float]] = field(default=None, init=False)
 
 
 @dataclass
@@ -58,12 +57,12 @@ class GraphData:
     Contains all necessary data for drawing a graph
 
     Attributes:
-        node_color (tuple): The color of the nodes in the graph.
-        edge_color (tuple): The color of the edges in the graph.
+        node_color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the nodes in the graph.
+        edge_color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the edges in the graph.
         draw_id (bool): Whether to draw the node IDs.
     """
-    node_color: tuple
+    node_color: Tuple[Union[int, float], Union[int, float], Union[int, float]]
     node_size: float
-    edge_color: tuple
+    edge_color: Tuple[Union[int, float], Union[int, float], Union[int, float]]
     draw_id: bool
-    edge_line_points: dict[int, list[tuple[float, float]]] = field(default_factory=dict)
+    edge_line_points: Dict[int, List[Tuple[float, float]]] = field(default_factory=dict)

--- a/gamms/VisualizationEngine/default_drawers.py
+++ b/gamms/VisualizationEngine/default_drawers.py
@@ -1,8 +1,8 @@
 from gamms.VisualizationEngine import Color
 from gamms.VisualizationEngine.builtin_artists import AgentData, GraphData
-from gamms.typing import IContext, OSMEdge, Node, ISensor
+from gamms.typing import IContext, OSMEdge, Node, ColorType
 
-from typing import Dict, Any, cast, Tuple, Union, List
+from typing import Dict, Any, cast, List
 
 import math
 
@@ -146,7 +146,7 @@ def render_input_overlay(ctx: IContext, data: Dict[str, Any]):
     for edge in active_edges:
         _render_graph_edge(ctx, graph_data, edge, edge_color)
 
-def _render_graph_edge(ctx: IContext, graph_data: GraphData, edge: OSMEdge, color: Tuple[Union[int, float], Union[int, float], Union[int, float]]):
+def _render_graph_edge(ctx: IContext, graph_data: GraphData, edge: OSMEdge, color: ColorType):
     """Draw an edge as a curve or straight line based on the linestring."""
     source = ctx.graph.graph.get_node(edge.source)
     target = ctx.graph.graph.get_node(edge.target)
@@ -165,7 +165,7 @@ def _render_graph_edge(ctx: IContext, graph_data: GraphData, edge: OSMEdge, colo
         ctx.visual.render_line(source.x, source.y, target.x, target.y, color, 2, perform_culling_test=False, is_aa=False)
 
 
-def _render_graph_node(ctx: IContext, node: Node, color: Tuple[Union[int, float], Union[int, float], Union[int, float]], radius: float, draw_id: bool):
+def _render_graph_node(ctx: IContext, node: Node, color: ColorType, radius: float, draw_id: bool):
     ctx.visual.render_circle(node.x, node.y, radius, color)
 
     if draw_id:

--- a/gamms/VisualizationEngine/default_drawers.py
+++ b/gamms/VisualizationEngine/default_drawers.py
@@ -1,13 +1,13 @@
 from gamms.VisualizationEngine import Color
 from gamms.VisualizationEngine.builtin_artists import AgentData, GraphData
-from gamms.typing import IContext
+from gamms.typing import IContext, OSMEdge, Node, ISensor
 
-from typing import Dict, Any
+from typing import Dict, Any, cast, Tuple, Union, List
 
 import math
 
 
-def render_circle(ctx: IContext, data: dict):
+def render_circle(ctx: IContext, data: Dict[str, Any]):
     """
     Render a circle at the specified position with the specified radius and color.
 
@@ -37,7 +37,7 @@ def render_rectangle(ctx: IContext, data: Dict[str, Any]):
     color = data.get('color', Color.Cyan)
     ctx.visual.render_rectangle(x, y, width, height, color)
 
-def render_agent(ctx: IContext, data: dict):
+def render_agent(ctx: IContext, data: Dict[str, Any]):
     """
     Render an agent as a triangle at its current position on the screen. This is the default rendering method for agents.
 
@@ -45,7 +45,7 @@ def render_agent(ctx: IContext, data: dict):
         ctx (Context): The current simulation context.
         data (dict): The data containing the agent's information.
     """
-    agent_data: AgentData = data.get('agent_data')
+    agent_data = cast(AgentData, data.get('agent_data'))
     size = agent_data.size
     color = agent_data.color
     is_waiting = data.get('_is_waiting', False)
@@ -60,13 +60,13 @@ def render_agent(ctx: IContext, data: dict):
         prev_node = ctx.graph.graph.get_node(agent.prev_node_id)
         prev_position = (prev_node.x, prev_node.y)
         target_position = (target_node.x, target_node.y)
-        edges = ctx.graph.graph.get_edges()
         current_edge = None
-        for _, edge in edges.items():
+        for edge_id in ctx.graph.graph.get_edges():
+            edge = ctx.graph.graph.get_edge(edge_id)
             if edge.source == agent.prev_node_id and edge.target == agent.current_node_id:
                 current_edge = edge
 
-        alpha = data.get('_alpha')
+        alpha = cast(float, data.get('_alpha'))
         if current_edge is not None:
             point = current_edge.linestring.interpolate(alpha, True)
             position = (point.x, point.y)
@@ -87,7 +87,7 @@ def render_agent(ctx: IContext, data: dict):
     ctx.visual.render_polygon([point1, point2, point3], color)
 
 
-def render_graph(ctx: IContext, data: dict):
+def render_graph(ctx: IContext, data: Dict[str, Any]):
     """
     Render the graph by drawing its nodes and edges on the screen. This is the default rendering method for graphs.
 
@@ -95,20 +95,21 @@ def render_graph(ctx: IContext, data: dict):
         ctx (Context): The current simulation context.
         data (dict): The data containing the graph's information.
     """
-    graph_data: GraphData = data.get('graph_data')
-    graph = ctx.graph.graph
+    graph_data = cast(GraphData, data.get('graph_data'))
     node_color = graph_data.node_color
     node_size = graph_data.node_size
     edge_color = graph_data.edge_color
     draw_id = graph_data.draw_id
 
-    for edge in graph.get_edges().values():
-        _render_graph_edge(ctx, graph_data, graph, edge, edge_color)
+    for edge_id in ctx.graph.graph.get_edges():
+        edge = ctx.graph.graph.get_edge(edge_id)
+        _render_graph_edge(ctx, graph_data, edge, edge_color)
         
-    for node in graph.get_nodes().values():
+    for node_id in ctx.graph.graph.get_nodes():
+        node = ctx.graph.graph.get_node(node_id)
         _render_graph_node(ctx, node, node_color, node_size, draw_id)
 
-def render_input_overlay(ctx: IContext, data: dict):
+def render_input_overlay(ctx: IContext, data: Dict[str, Any]):
     """
     Render the graph by drawing its nodes and edges on the screen. This is the default rendering method for graphs.
 
@@ -116,7 +117,7 @@ def render_input_overlay(ctx: IContext, data: dict):
         ctx (Context): The current simulation context.
         data (dict): The data containing the graph's information.
     """
-    graph_data: GraphData = data.get('graph_data')
+    graph_data = cast(GraphData, data.get('graph_data'))
     waiting_agent_name = data.get('_waiting_agent_name', None)
     input_options = data.get('_input_options', {})
     waiting_user_input = data.get('_waiting_user_input', False)
@@ -135,27 +136,25 @@ def render_input_overlay(ctx: IContext, data: dict):
     for node in target_node_id_set:
         _render_graph_node(ctx, graph.get_node(node), node_color, node_size, draw_id)
 
-    active_edges = []
-    for edge in graph.get_edges().values():
+    active_edges: List[OSMEdge] = []
+    for edge_id in graph.get_edges():
+        edge = graph.get_edge(edge_id)
         current_waiting_agent = ctx.agent.get_agent(waiting_agent_name)
-        if (current_waiting_agent is not None and edge.source == current_waiting_agent.current_node_id and
-                edge.target in target_node_id_set):
+        if (edge.source == current_waiting_agent.current_node_id and edge.target in target_node_id_set):
             active_edges.append(edge)
 
     for edge in active_edges:
-        _render_graph_edge(ctx, graph_data, graph, edge, edge_color)
+        _render_graph_edge(ctx, graph_data, edge, edge_color)
 
-def _render_graph_edge(ctx: IContext, graph_data, graph, edge, color):
+def _render_graph_edge(ctx: IContext, graph_data: GraphData, edge: OSMEdge, color: Tuple[Union[int, float], Union[int, float], Union[int, float]]):
     """Draw an edge as a curve or straight line based on the linestring."""
-    source = graph.get_node(edge.source)
-    target = graph.get_node(edge.target)
+    source = ctx.graph.graph.get_node(edge.source)
+    target = ctx.graph.graph.get_node(edge.target)
 
     if edge.linestring:
         edge_line_points = graph_data.edge_line_points
         if edge.id not in edge_line_points:
             # linestring[1:-1]
-            source = graph.get_node(edge.source)
-            target = graph.get_node(edge.target)
             linestring = ([(source.x, source.y)] + [(x, y) for (x, y) in edge.linestring.coords] +
                             [(target.x, target.y)])
             edge_line_points[edge.id] = linestring
@@ -163,45 +162,45 @@ def _render_graph_edge(ctx: IContext, graph_data, graph, edge, color):
         line_points = edge_line_points[edge.id]
         ctx.visual.render_linestring(line_points, color, is_aa=True, perform_culling_test=False)
     else:
-        ctx.visual.render_line(source.x, source.y, target.x, target.y, color, 2, perform_culling_test=False)
+        ctx.visual.render_line(source.x, source.y, target.x, target.y, color, 2, perform_culling_test=False, is_aa=False)
 
 
-def _render_graph_node(ctx: IContext, node, color, radius, draw_id):
+def _render_graph_node(ctx: IContext, node: Node, color: Tuple[Union[int, float], Union[int, float], Union[int, float]], radius: float, draw_id: bool):
     ctx.visual.render_circle(node.x, node.y, radius, color)
 
     if draw_id:
         ctx.visual.render_text(str(node.id), node.x, node.y + 10, (0, 0, 0))
 
 
-def render_neighbor_sensor(ctx: IContext, data: dict):
+def render_neighbor_sensor(ctx: IContext, data: Dict[str, Any]):
     """
     Render a neighbor sensor.
 
     Args:
         ctx (Context): The current simulation context.
-        data (dict): The data containing the sensor's information.
+        data (Dict[str, Any]): The data containing the sensor's information.
     """
-    sensor = data.get('sensor')
+    sensor = ctx.sensor.get_sensor(data.get('name'))
     color = data.get('color', Color.Cyan)
-    sensor_data: dict = sensor.data
+    sensor_data = cast(List[int], sensor.data)
     for neighbor_node_id in sensor_data:
         neighbor_node = ctx.graph.graph.get_node(neighbor_node_id)
         ctx.visual.render_circle(neighbor_node.x, neighbor_node.y, 2, color)
 
 
-def render_map_sensor(ctx: IContext, data: dict):
+def render_map_sensor(ctx: IContext, data: Dict[str, Any]):
     """
     Render a map sensor.
 
     Args:
         ctx (Context): The current simulation context.
-        data (dict): The data containing the sensor's information.
+        data (Dict[str, Any]): The data containing the sensor's information.
     """
-    sensor = data.get('sensor')
+    sensor = ctx.sensor.get_sensor(data.get('name'))
     node_color = data.get('node_color', Color.Cyan)
-    sensor_data: dict = sensor.data
+    sensor_data = cast(Dict[str, Any], sensor.data)
 
-    sensed_nodes = sensor_data.get('nodes', {})
+    sensed_nodes = cast(Dict[int, Node], sensor_data.get('nodes', {}))
     sensed_nodes = list(sensed_nodes.keys())
     for node_id in sensed_nodes:
         node = ctx.graph.graph.get_node(node_id)
@@ -224,18 +223,18 @@ def render_map_sensor(ctx: IContext, data: dict):
             ctx.visual.render_line(source.x, source.y, target.x, target.y, edge_color, 4, perform_culling_test=False)
 
 
-def render_agent_sensor(ctx: IContext, data: dict):
+def render_agent_sensor(ctx: IContext, data: Dict[str, Any]):
     """
     Render an agent sensor.
 
     Args:
         ctx (Context): The current simulation context.
-        data (dict): The data containing the sensor's information.
+        data (Dict[str, Any]): The data containing the sensor's information.
     """
-    sensor = data.get('sensor')
+    sensor = ctx.sensor.get_sensor(data.get('name'))
     color = data.get('color', Color.Cyan)
     size = data.get('size', 8)
-    sensor_data: dict = sensor.data
+    sensor_data = cast(Dict[str, int], sensor.data)
     for node_id in sensor_data.values():
         target_node = ctx.graph.graph.get_node(node_id)
         position = (target_node.x, target_node.y)

--- a/gamms/VisualizationEngine/no_engine.py
+++ b/gamms/VisualizationEngine/no_engine.py
@@ -1,30 +1,36 @@
-from gamms.typing import IVisualizationEngine
-from gamms.typing import IArtist
+from gamms.typing import (
+    IArtist,
+    IContext,
+    IVisualizationEngine,
+)
 from gamms.typing.opcodes import OpCodes
-from gamms.context import Context
 from gamms.VisualizationEngine.artist import Artist
-from gamms.VisualizationEngine import Color, Space
+from gamms.VisualizationEngine import Color
 
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Callable, cast, Union
 
 class NoEngine(IVisualizationEngine):
-    def __init__(self, ctx: Context, **kwargs):
+    def __init__(self, ctx: IContext, **kwargs: Dict[str, Any]) -> None:
         self.ctx = ctx
     
-    def set_graph_visual(self, **kwargs) -> IArtist:
-        dummy = lambda ctx, data: None
+    def set_graph_visual(self, **kwargs: Dict[str, Any]) -> IArtist:
+        dummy = cast(Callable[[IContext, Dict[str, Any]], None], lambda ctx, data: None)
         return Artist(self.ctx , dummy, layer=10)
     
-    def set_agent_visual(self, agent_name: str, **kwargs) -> IArtist:
-        dummy = lambda ctx, data: None
+    def set_agent_visual(self, name: str, **kwargs: Dict[str, Any]) -> IArtist:
+        dummy = cast(Callable[[IContext, Dict[str, Any]], None], lambda ctx, data: None)
         return Artist(self.ctx , dummy, layer=20)
     
-    def set_sensor_visual(self, sensor_name: str, **kwargs) -> IArtist:
-        dummy = lambda ctx, data: None
+    def set_sensor_visual(self, name: str, **kwargs: Dict[str, Any]) -> IArtist:
+        dummy = cast(Callable[[IContext, Dict[str, Any]], None], lambda ctx, data: None)
         return Artist(self.ctx , dummy, layer=40)
     
-    def add_artist(self, name:str, artist: IArtist) -> None:
-        return
+    def add_artist(self, name: str, artist: Union[IArtist, Dict[str, Any]]) -> IArtist:
+        if isinstance(artist, dict):
+            dummy = cast(Callable[[IContext, Dict[str, Any]], None], lambda ctx, data: None)
+            artist = Artist(self.ctx, dummy, layer=30)
+            artist.data = artist
+        return artist
     
     def remove_artist(self, name: str):
         return
@@ -40,25 +46,28 @@ class NoEngine(IVisualizationEngine):
     def terminate(self):
         return
 
-    def render_circle(self, x: float, y: float, radius: float, color: tuple=Color.Black, layer = -1,
+    def render_text(self, text: str, x: float, y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black, perform_culling_test: bool=True):
+        return
+
+    def render_rectangle(self, x: float, y: float, width: float, height: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
+                         perform_culling_test: bool=True):
+        return
+
+    def render_circle(self, x: float, y: float, radius: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
                       perform_culling_test: bool=True):
         return
 
-    def render_rectangle(self, x: float, y: float, width: float, height: float, color: tuple = Color.Black, layer = -1,
-                         perform_culling_test: bool = True):
+    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
+                    width: int=1, is_aa: bool=False, perform_culling_test: bool=True, force_no_aa: bool = False):
         return
 
-    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: tuple = Color.Black,
-                    width: int = 1, layer = -1, is_aa: bool = False, perform_culling_test: bool = True):
+    def render_linestring(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]] =Color.Black, width: int=1, closed: bool = False,
+                     is_aa: bool=False, perform_culling_test: bool=True):
         return
 
-    def render_linestring(self, points: List[Tuple[float, float]], color: tuple = Color.Black, width: int = 1, layer = -1, closed=False,
-                     is_aa: bool = False, perform_culling_test: bool = True):
+    def render_polygon(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black, width: int=0,
+                       perform_culling_test: bool=True):
         return
-
-    def render_polygon(self, points: List[Tuple[float, float]], color: tuple = Color.Black, width: int = 0, layer = -1,
-                       perform_culling_test: bool = True):
-        return
-
-    def render_text(self, text: str, x: float, y: float, color: tuple = Color.Black, layer = -1, perform_culling_test: bool=True):
+    
+    def render_layer(self, layer_id: int) -> None:
         return

--- a/gamms/VisualizationEngine/no_engine.py
+++ b/gamms/VisualizationEngine/no_engine.py
@@ -2,6 +2,7 @@ from gamms.typing import (
     IArtist,
     IContext,
     IVisualizationEngine,
+    ColorType
 )
 from gamms.typing.opcodes import OpCodes
 from gamms.VisualizationEngine.artist import Artist
@@ -46,26 +47,26 @@ class NoEngine(IVisualizationEngine):
     def terminate(self):
         return
 
-    def render_text(self, text: str, x: float, y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black, perform_culling_test: bool=True):
+    def render_text(self, text: str, x: float, y: float, color: ColorType = Color.Black, perform_culling_test: bool=True):
         return
 
-    def render_rectangle(self, x: float, y: float, width: float, height: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
+    def render_rectangle(self, x: float, y: float, width: float, height: float, color: ColorType = Color.Black,
                          perform_culling_test: bool=True):
         return
 
-    def render_circle(self, x: float, y: float, radius: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
+    def render_circle(self, x: float, y: float, radius: float, color: ColorType = Color.Black,
                       perform_culling_test: bool=True):
         return
 
-    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
+    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: ColorType = Color.Black,
                     width: int=1, is_aa: bool=False, perform_culling_test: bool=True, force_no_aa: bool = False):
         return
 
-    def render_linestring(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]] =Color.Black, width: int=1, closed: bool = False,
+    def render_linestring(self, points: List[Tuple[float, float]], color: ColorType =Color.Black, width: int=1, closed: bool = False,
                      is_aa: bool=False, perform_culling_test: bool=True):
         return
 
-    def render_polygon(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black, width: int=0,
+    def render_polygon(self, points: List[Tuple[float, float]], color: ColorType = Color.Black, width: int=0,
                        perform_culling_test: bool=True):
         return
     

--- a/gamms/VisualizationEngine/pygame_engine.py
+++ b/gamms/VisualizationEngine/pygame_engine.py
@@ -1,20 +1,20 @@
-from gamms.typing import IVisualizationEngine
 from gamms.VisualizationEngine import Color, Space, Shape, Artist, lazy
 from gamms.VisualizationEngine.render_manager import RenderManager
 from gamms.VisualizationEngine.builtin_artists import AgentData, GraphData
 from gamms.VisualizationEngine.default_drawers import render_circle, render_rectangle, \
     render_agent, render_graph, render_neighbor_sensor, render_map_sensor, render_agent_sensor, render_input_overlay
 from gamms.typing import (
+    IVisualizationEngine,
     IArtist,
     ArtistType,
     IContext,
     SensorType, 
     OpCodes
 )
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Union, cast
 
 class PygameVisualizationEngine(IVisualizationEngine):
-    def __init__(self, ctx, width=1280, height=720, simulation_time_constant=2.0, **kwargs):
+    def __init__(self, ctx: IContext, width: int = 1280, height: int = 720, simulation_time_constant: float = 2.0, **kwargs : Dict[str, Any]):
         pygame = lazy('pygame')
         repr(pygame)
         try:
@@ -34,17 +34,14 @@ class PygameVisualizationEngine(IVisualizationEngine):
         self._simulation_time = 0
         self._will_quit = False
         self._render_manager = RenderManager(ctx, 0, 0, 15, width, height)
-        self._surface_dict : dict[int, self._pygame.Surface ] = {}
-        self._agent_artists: dict[str, IArtist] = {}
-        self._graph_artists: dict[str, IArtist] = {}
+        self._surface_dict : Dict[int, self._pygame.Surface ] = {}
+        self._agent_artists: Dict[str, IArtist] = {}
+        self._graph_artists: Dict[str, IArtist] = {}
 
         input_overlay_args = kwargs.get('input_overlay', {})
         self._input_overlay_artist = self._set_input_overlay_artist(input_overlay_args)
     
     def create_layer(self, layer_id: int, width : int, height : int) -> int:
-        if layer_id is None:
-            layer_id = 0
-
         if layer_id not in self._surface_dict:
             surface = self._pygame.Surface((width, height), self._pygame.SRCALPHA)
             self._surface_dict[layer_id] = surface
@@ -54,11 +51,13 @@ class PygameVisualizationEngine(IVisualizationEngine):
 
         return layer_id
 
-    def set_graph_visual(self, **kwargs):
-        graph = self.ctx.graph.graph
-
-        x_list = [node.x for node in graph.get_nodes().values()]
-        y_list = [node.y for node in graph.get_nodes().values()]
+    def set_graph_visual(self, **kwargs: Dict[str, Any]) -> IArtist:
+        x_list: List[float] = []
+        y_list: List[float] = []
+        for node_id in self.ctx.graph.graph.get_nodes():
+            node = self.ctx.graph.graph.get_node(node_id)
+            x_list.append(node.x)
+            y_list.append(node.y)
         x_min = min(x_list, default=0.0)
         x_max = max(x_list, default=0.0)
         y_min = min(y_list, default=0.0)
@@ -71,12 +70,13 @@ class PygameVisualizationEngine(IVisualizationEngine):
 
         width = self._render_manager.screen_width
         height = self._render_manager.screen_height
-        layer_id = self.create_layer(10, width, height)
         
-        graph_data = GraphData(node_color=kwargs.get('node_color', Color.DarkGray),
-                               node_size=kwargs.get('node_size', 2),
-                               edge_color=kwargs.get('edge_color', Color.LightGray), 
-                               draw_id=kwargs.get('draw_id', False))
+        self.create_layer(10, width, height)
+        
+        graph_data = GraphData(node_color=cast(Tuple[Union[int, float], Union[int, float], Union[int, float]], kwargs.get('node_color', Color.DarkGray)),
+                               node_size=cast(int, kwargs.get('node_size', 2)),
+                               edge_color=cast(Tuple[Union[int, float], Union[int, float], Union[int, float]], kwargs.get('edge_color', Color.LightGray)), 
+                               draw_id=cast(bool, kwargs.get('draw_id', False)))
 
         artist = Artist(self.ctx, render_graph, 10)
         artist.data['graph_data'] = graph_data
@@ -91,7 +91,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
 
         return artist
 
-    def _set_input_overlay_artist(self, args: dict):
+    def _set_input_overlay_artist(self, args: Dict[str, Any]) -> IArtist:
         graph_data = GraphData(node_color = args.get('node_color', Color.Green),
                                node_size = args.get('node_size', 4),
                                edge_color = args.get('edge_color', Color.Green),
@@ -108,9 +108,13 @@ class PygameVisualizationEngine(IVisualizationEngine):
         
         return artist
     
-    def set_agent_visual(self, name, **kwargs):
+    def set_agent_visual(self, name: str, **kwargs: Dict[str, Any]) -> IArtist:
         
-        agent_data = AgentData(name=name, color=kwargs.get('color', Color.Black), size=kwargs.get('size', 8))
+        agent_data = AgentData(
+            name=name,
+            color=cast(Tuple[Union[int, float], Union[int, float], Union[int, float]], kwargs.get('color', Color.Black)),
+            size=cast(int,kwargs.get('size', 8))
+        )
 
         artist = Artist(self.ctx, render_agent, 20)
         artist.data['agent_data'] = agent_data
@@ -121,54 +125,53 @@ class PygameVisualizationEngine(IVisualizationEngine):
 
         return artist
 
-    def set_sensor_visual(self, sensor_name, **kwargs):
-        sensor = self.ctx.sensor.get_sensor(sensor_name)
+    def set_sensor_visual(self, name: str, **kwargs: Dict[str, Any]) -> IArtist:
+        sensor = self.ctx.sensor.get_sensor(name)
         sensor_type = sensor.type
-        artist = Artist(self.ctx, None, kwargs.get('layer', 30))
-        artist.data['sensor'] = sensor
+
+        data: Dict[str, Any] = {
+            'name': sensor.sensor_id,
+        }
 
         if sensor_type == SensorType.NEIGHBOR:
-            artist.set_drawer(render_neighbor_sensor)
-            artist.data['color'] = kwargs.get('color', Color.Cyan)
-            artist.data['size'] = kwargs.get('size', 8)
+            drawer = render_neighbor_sensor
+            data['color'] = kwargs.pop('color', Color.Cyan)
+            data['size'] = kwargs.pop('size', 8)
         elif sensor_type == SensorType.MAP or sensor_type == SensorType.RANGE or sensor_type == SensorType.ARC:
-            artist.set_drawer(render_map_sensor)
-            artist.data['node_color'] = kwargs.get('node_color', Color.Cyan)
-            artist.data['edge_color'] = kwargs.get('edge_color', Color.Cyan)
+            drawer = render_map_sensor
+            data['node_color'] = kwargs.pop('node_color', Color.Cyan)
+            data['edge_color'] = kwargs.pop('edge_color', Color.Cyan)
         elif sensor_type == SensorType.AGENT or sensor_type == SensorType.AGENT_RANGE or sensor_type == SensorType.AGENT_ARC:
-            artist.set_drawer(render_agent_sensor)
-            artist.data['color'] = kwargs.get('color', Color.Cyan)
-            artist.data['size'] = kwargs.get('size', 8)
+            drawer = render_agent_sensor
+            data['color'] = kwargs.pop('color', Color.Cyan)
+            data['size'] = kwargs.pop('size', 8)
         else:
             raise ValueError(f"Invalid sensor type: {sensor_type}")
-
-        self.add_artist(f'sensor_{sensor_name}', artist)
+        
+        layer = kwargs.pop('layer', 30)
+        artist = Artist(self.ctx, drawer, layer)
+        artist.data.update(data)
+        
+        self.add_artist(f'sensor_{name}', artist)
 
         return artist
     
-    def add_artist(self, name: str, artist: IArtist | dict) -> IArtist | None:
+    def add_artist(self, name: str, artist: Union[IArtist, Dict[str, Any]]) -> IArtist:
         if isinstance(artist, IArtist):
             artist_to_add = artist
         else:
             shape = artist.get('shape', None)
             drawer = artist.get('drawer', None)
             layer = artist.get('layer', 30)
-            if shape is None and drawer is None:
-                self.ctx.logger.error(f"Both shape and drawer are empty for artist {name}. Ignoring this artist.")
-                return None
 
             if shape is not None and drawer is not None:
                 self.ctx.logger.warning(f"Both shape and drawer are set for artist {name}, will use drawer.")
-            
-            if drawer is None:
-                if shape == Shape.Circle:
-                    drawer = render_circle
-                elif shape == Shape.Rectangle:
-                    drawer = render_rectangle
-                else:
-                    self.ctx.logger.error(f"Invalid shape {shape} for artist {name}. Ignoring this artist.")
-                    return None
-                
+
+            if drawer is None and shape is not None:
+                drawer = shape
+            else:
+                drawer = Shape.Circle
+
             artist_to_add = Artist(self.ctx, drawer, layer)
             artist_to_add.data = artist
 
@@ -184,7 +187,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         self._render_manager.add_artist(name, artist_to_add)
         return artist_to_add
 
-    def remove_artist(self, name):
+    def remove_artist(self, name: str):
         self._render_manager.remove_artist(name)
 
     def handle_input(self):
@@ -277,7 +280,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         top += size_y + 10
         size_x, size_y = self._render_text_internal(f"FPS: {round(self._clock.get_fps(), 2)}", 10, top, Space.Screen)
 
-    def _render_text_internal(self, text: str, x: float, y: float, coord_space: Space=Space.World, color: tuple=Color.Black):
+    def _render_text_internal(self, text: str, x: float, y: float, coord_space: Space=Space.World, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black):
         if coord_space == Space.World:
             screen_x, screen_y = self._render_manager.world_to_screen(x, y)
         elif coord_space == Space.Screen:
@@ -323,7 +326,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         else:
             return self._screen
 
-    def render_text(self, text: str, x: float, y: float, color: tuple = Color.Black, perform_culling_test: bool=True):
+    def render_text(self, text: str, x: float, y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black, perform_culling_test: bool=True):
         text_size = self._default_font.size(text)
         if perform_culling_test and self._render_manager.check_rectangle_culled(x, y, text_size[0], text_size[1]):
             return
@@ -333,22 +336,28 @@ class PygameVisualizationEngine(IVisualizationEngine):
         text_rect = text_surface.get_rect(center=(x, y))
         text_rect.move_ip(text_size[0] / 2, text_size[1] / 2)
 
+        if self._render_manager.current_drawing_artist is None:
+            raise ValueError("No current drawing artist set.")
+
         layer = self._render_manager.current_drawing_artist.get_layer()
         surface = self._get_target_surface(layer)
         surface.blit(text_surface, text_rect)
 
-    def render_rectangle(self, x: float, y: float, width: float, height: float, color: tuple=Color.Black,
+    def render_rectangle(self, x: float, y: float, width: float, height: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
                          perform_culling_test: bool=True):
         if perform_culling_test and self._render_manager.check_rectangle_culled(x, y, width, height):
             return
 
         (x, y) = self._render_manager.world_to_screen(x, y)
 
+        if self._render_manager.current_drawing_artist is None:
+            raise ValueError("No current drawing artist set.")
+
         layer = self._render_manager.current_drawing_artist.get_layer()
         surface = self._get_target_surface(layer)
         self._pygame.draw.rect(surface, color, self._pygame.Rect(x, y, width, height))
 
-    def render_circle(self, x: float, y: float, radius: float, color: tuple=Color.Black,
+    def render_circle(self, x: float, y: float, radius: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
                       perform_culling_test: bool=True):
         if perform_culling_test and self._render_manager.check_circle_culled(x, y, radius):
             return
@@ -357,17 +366,24 @@ class PygameVisualizationEngine(IVisualizationEngine):
         if radius < 1:
             return
         (x, y) = self._render_manager.world_to_screen(x, y)
+
+        if self._render_manager.current_drawing_artist is None:
+            raise ValueError("No current drawing artist set.")
+        
         layer = self._render_manager.current_drawing_artist.get_layer()
         surface = self._get_target_surface(layer)
         self._pygame.draw.circle(surface, color, (x, y), radius)
 
-    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: tuple=Color.Black,
+    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
                     width: int=1, is_aa: bool=False, perform_culling_test: bool=True, force_no_aa: bool = False):
         if perform_culling_test and self._render_manager.check_line_culled(start_x, start_y, end_x, end_y):
             return
 
         (start_x, start_y) = self._render_manager.world_to_screen(start_x, start_y)
         (end_x, end_y) = self._render_manager.world_to_screen(end_x, end_y)
+
+        if self._render_manager.current_drawing_artist is None:
+            raise ValueError("No current drawing artist set.")
 
         layer = self._render_manager.current_drawing_artist.get_layer()
         surface = self._get_target_surface(layer)
@@ -376,12 +392,15 @@ class PygameVisualizationEngine(IVisualizationEngine):
         else:
             self._pygame.draw.line(surface, color, (start_x, start_y), (end_x, end_y), width)
 
-    def render_linestring(self, points: List[Tuple[float, float]], color: tuple=Color.Black, width: int=1, closed=False,
+    def render_linestring(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]] =Color.Black, width: int=1, closed: bool = False,
                      is_aa: bool=False, perform_culling_test: bool=True):
         if perform_culling_test and self._render_manager.check_lines_culled(points):
             return
 
         points = [self._render_manager.world_to_screen(point[0], point[1]) for point in points]
+
+        if self._render_manager.current_drawing_artist is None:
+            raise ValueError("No current drawing artist set.")
 
         layer = self._render_manager.current_drawing_artist.get_layer()
         surface = self._get_target_surface(layer)
@@ -390,12 +409,15 @@ class PygameVisualizationEngine(IVisualizationEngine):
         else:
             self._pygame.draw.lines(surface, color, closed, points, width)
 
-    def render_polygon(self, points: List[Tuple[float, float]], color: tuple=Color.Black, width: int=0,
+    def render_polygon(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black, width: int=0,
                        perform_culling_test: bool=True):
         if perform_culling_test and self._render_manager.check_polygon_culled(points):
             return
 
         points = [self._render_manager.world_to_screen(point[0], point[1]) for point in points]
+
+        if self._render_manager.current_drawing_artist is None:
+            raise ValueError("No current drawing artist set.")
 
         layer = self._render_manager.current_drawing_artist.get_layer()
         surface = self._get_target_surface(layer)
@@ -405,7 +427,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         if layer_id in self._surface_dict:
             self._surface_dict[layer_id].fill((0, 0, 0, 0))
 
-    def fill_layer(self, layer_id: int, color: tuple):
+    def fill_layer(self, layer_id: int, color: Tuple[Union[int, float], Union[int, float], Union[int, float]]):
         if layer_id in self._surface_dict:
             self._surface_dict[layer_id].fill(color)
 
@@ -439,14 +461,15 @@ class PygameVisualizationEngine(IVisualizationEngine):
         self.handle_tick()
         self._pygame.display.flip()
 
-    def human_input(self, agent_name, state: Dict[str, Any]) -> int:
+    def human_input(self, agent_name: str, state: Dict[str, Any]) -> int:
         if self.ctx.is_terminated():
             return state["curr_pos"]
         self._toggle_waiting_user_input(True)
-        def get_neighbours(state):
+        def get_neighbours(state: Dict[str, Any]) -> List[int]:
             for (type, data) in state["sensor"].values():
                 if type == SensorType.NEIGHBOR:
                     return data
+            return []
 
         prev_waiting_agent_name = self._waiting_agent_name
         if prev_waiting_agent_name is not None:
@@ -483,6 +506,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
             if result is not None:
                 self.end_handle_human_input()
                 return result                
+        return state["curr_pos"]
 
     def end_handle_human_input(self):
         for agent_artist in self._agent_artists.values():

--- a/gamms/VisualizationEngine/pygame_engine.py
+++ b/gamms/VisualizationEngine/pygame_engine.py
@@ -9,7 +9,8 @@ from gamms.typing import (
     ArtistType,
     IContext,
     SensorType, 
-    OpCodes
+    OpCodes,
+    ColorType
 )
 from typing import Dict, Any, List, Tuple, Union, cast
 
@@ -73,9 +74,9 @@ class PygameVisualizationEngine(IVisualizationEngine):
         
         self.create_layer(10, width, height)
         
-        graph_data = GraphData(node_color=cast(Tuple[Union[int, float], Union[int, float], Union[int, float]], kwargs.get('node_color', Color.DarkGray)),
+        graph_data = GraphData(node_color=cast(ColorType, kwargs.get('node_color', Color.DarkGray)),
                                node_size=cast(int, kwargs.get('node_size', 2)),
-                               edge_color=cast(Tuple[Union[int, float], Union[int, float], Union[int, float]], kwargs.get('edge_color', Color.LightGray)), 
+                               edge_color=cast(ColorType, kwargs.get('edge_color', Color.LightGray)), 
                                draw_id=cast(bool, kwargs.get('draw_id', False)))
 
         artist = Artist(self.ctx, render_graph, 10)
@@ -112,7 +113,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         
         agent_data = AgentData(
             name=name,
-            color=cast(Tuple[Union[int, float], Union[int, float], Union[int, float]], kwargs.get('color', Color.Black)),
+            color=cast(ColorType, kwargs.get('color', Color.Black)),
             size=cast(int,kwargs.get('size', 8))
         )
 
@@ -148,7 +149,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         else:
             raise ValueError(f"Invalid sensor type: {sensor_type}")
         
-        layer = kwargs.pop('layer', 30)
+        layer = cast(int, kwargs.pop('layer', 30))
         artist = Artist(self.ctx, drawer, layer)
         artist.data.update(data)
         
@@ -174,9 +175,6 @@ class PygameVisualizationEngine(IVisualizationEngine):
 
             artist_to_add = Artist(self.ctx, drawer, layer)
             artist_to_add.data = artist
-
-        if artist_to_add.get_drawer() is None:
-            raise ValueError("Drawer must be set in the artist object.")
 
         layer = artist_to_add.get_layer()
         if artist_to_add.get_artist_type() == ArtistType.AGENT:
@@ -280,7 +278,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         top += size_y + 10
         size_x, size_y = self._render_text_internal(f"FPS: {round(self._clock.get_fps(), 2)}", 10, top, Space.Screen)
 
-    def _render_text_internal(self, text: str, x: float, y: float, coord_space: Space=Space.World, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black):
+    def _render_text_internal(self, text: str, x: float, y: float, coord_space: Space=Space.World, color: ColorType = Color.Black):
         if coord_space == Space.World:
             screen_x, screen_y = self._render_manager.world_to_screen(x, y)
         elif coord_space == Space.Screen:
@@ -326,7 +324,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         else:
             return self._screen
 
-    def render_text(self, text: str, x: float, y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black, perform_culling_test: bool=True):
+    def render_text(self, text: str, x: float, y: float, color: ColorType = Color.Black, perform_culling_test: bool=True):
         text_size = self._default_font.size(text)
         if perform_culling_test and self._render_manager.check_rectangle_culled(x, y, text_size[0], text_size[1]):
             return
@@ -343,7 +341,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         surface = self._get_target_surface(layer)
         surface.blit(text_surface, text_rect)
 
-    def render_rectangle(self, x: float, y: float, width: float, height: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
+    def render_rectangle(self, x: float, y: float, width: float, height: float, color: ColorType = Color.Black,
                          perform_culling_test: bool=True):
         if perform_culling_test and self._render_manager.check_rectangle_culled(x, y, width, height):
             return
@@ -357,7 +355,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         surface = self._get_target_surface(layer)
         self._pygame.draw.rect(surface, color, self._pygame.Rect(x, y, width, height))
 
-    def render_circle(self, x: float, y: float, radius: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
+    def render_circle(self, x: float, y: float, radius: float, color: ColorType = Color.Black,
                       perform_culling_test: bool=True):
         if perform_culling_test and self._render_manager.check_circle_culled(x, y, radius):
             return
@@ -374,7 +372,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         surface = self._get_target_surface(layer)
         self._pygame.draw.circle(surface, color, (x, y), radius)
 
-    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black,
+    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: ColorType = Color.Black,
                     width: int=1, is_aa: bool=False, perform_culling_test: bool=True, force_no_aa: bool = False):
         if perform_culling_test and self._render_manager.check_line_culled(start_x, start_y, end_x, end_y):
             return
@@ -392,7 +390,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         else:
             self._pygame.draw.line(surface, color, (start_x, start_y), (end_x, end_y), width)
 
-    def render_linestring(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]] =Color.Black, width: int=1, closed: bool = False,
+    def render_linestring(self, points: List[Tuple[float, float]], color: ColorType =Color.Black, width: int=1, closed: bool = False,
                      is_aa: bool=False, perform_culling_test: bool=True):
         if perform_culling_test and self._render_manager.check_lines_culled(points):
             return
@@ -409,7 +407,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         else:
             self._pygame.draw.lines(surface, color, closed, points, width)
 
-    def render_polygon(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]] = Color.Black, width: int=0,
+    def render_polygon(self, points: List[Tuple[float, float]], color: ColorType = Color.Black, width: int=0,
                        perform_culling_test: bool=True):
         if perform_culling_test and self._render_manager.check_polygon_culled(points):
             return
@@ -427,7 +425,7 @@ class PygameVisualizationEngine(IVisualizationEngine):
         if layer_id in self._surface_dict:
             self._surface_dict[layer_id].fill((0, 0, 0, 0))
 
-    def fill_layer(self, layer_id: int, color: Tuple[Union[int, float], Union[int, float], Union[int, float]]):
+    def fill_layer(self, layer_id: int, color: ColorType):
         if layer_id in self._surface_dict:
             self._surface_dict[layer_id].fill(color)
 

--- a/gamms/typing/__init__.py
+++ b/gamms/typing/__init__.py
@@ -6,7 +6,7 @@ from gamms.typing.sensor_engine import ISensorEngine, ISensor, SensorType
 from gamms.typing.artist import IArtist, ArtistType
 from gamms.typing.visualization_engine import IVisualizationEngine
 from gamms.typing.agent_engine import IAgentEngine, IAgent
-from gamms.typing.graph_engine import IGraphEngine, IGraph
+from gamms.typing.graph_engine import IGraphEngine, IGraph, OSMEdge, Node
 from gamms.typing.recorder import IRecorder
 from gamms.typing.logger import ILogger
 from gamms.typing.context import IContext

--- a/gamms/typing/__init__.py
+++ b/gamms/typing/__init__.py
@@ -4,7 +4,7 @@ from gamms.typing.message_engine import IMessageEngine
 from gamms.typing.internal_context import IInternalContext
 from gamms.typing.sensor_engine import ISensorEngine, ISensor, SensorType
 from gamms.typing.artist import IArtist, ArtistType
-from gamms.typing.visualization_engine import IVisualizationEngine
+from gamms.typing.visualization_engine import IVisualizationEngine, ColorType
 from gamms.typing.agent_engine import IAgentEngine, IAgent
 from gamms.typing.graph_engine import IGraphEngine, IGraph, OSMEdge, Node
 from gamms.typing.recorder import IRecorder

--- a/gamms/typing/agent_engine.py
+++ b/gamms/typing/agent_engine.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, Dict, Any, Optional, Callable
+from typing import Iterable, Dict, Any, Optional, Callable, Tuple
+from gamms.typing.sensor_engine import ISensor
 
 class IAgent(ABC):
     """
@@ -28,6 +29,17 @@ class IAgent(ABC):
     def prev_node_id(self) -> int:
         """
         Get the previous node ID of the agent.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def orientation(self) -> Tuple[float, float]:
+        """
+        Get the orientation of the agent.
+
+        Returns:
+            int: The current orientation of the agent.
         """
         pass
     
@@ -74,17 +86,14 @@ class IAgent(ABC):
         pass
 
     @abstractmethod
-    def set_state(self, state):
+    def set_state(self):
         """
         Update the agent's state.
-
-        Args:
-            state (Dict[str, Any]): The new state data to set for the agent.
         """
         pass
 
     @abstractmethod
-    def register_sensor(self, name, sensor):
+    def register_sensor(self, name: str, sensor: ISensor):
         """
         Register a sensor with the agent.
 
@@ -97,7 +106,7 @@ class IAgent(ABC):
         pass
 
     @abstractmethod
-    def deregister_sensor(self, name):
+    def deregister_sensor(self, name: str):
         """
         Deregister a sensor from the agent.
 
@@ -107,7 +116,7 @@ class IAgent(ABC):
         pass
 
     @abstractmethod
-    def register_strategy(self, strategy):
+    def register_strategy(self, strategy: Callable[[Dict[str, Any]], None]):
         """
         Register a strategy with the agent.
 
@@ -138,12 +147,12 @@ class IAgentEngine(ABC):
         pass
 
     @abstractmethod
-    def create_agent(self, start_node_id: int, **kwargs) -> IAgent:
+    def create_agent(self, name:str, **kwargs: Dict[str, Any]) -> IAgent:
         """
         Instantiate a new agent within the engine.
 
         Args:
-            start_node_id (int): The identifier for the starting node or position of the agent.
+            name (str): The unique name identifier for the agent.
             **kwargs: Additional keyword arguments for agent initialization.
 
         Returns:
@@ -151,6 +160,7 @@ class IAgentEngine(ABC):
         
         Raises:
             ValueError: If an agent with the same name already exists.
+            KeyError: If start_node_id is not provided in kwargs.
         """
         pass
 

--- a/gamms/typing/artist.py
+++ b/gamms/typing/artist.py
@@ -1,7 +1,6 @@
-from typing import Dict, Any, Callable, Union
+from typing import Dict, Any, Callable, Union, Optional
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-
 
 class ArtistType(Enum):
     GENERAL = auto()
@@ -60,22 +59,22 @@ class IArtist(ABC):
         pass
 
     @abstractmethod
-    def set_drawer(self, drawer: Callable) -> None:
+    def set_drawer(self, drawer: Callable[["IContext", Dict[str, Any]], None]) -> None:
         """
         Set the drawer function for the artist.
 
         Args:
-            drawer (Callable): The drawer function to set.
+            drawer (Callable[[IContext, Dict[str, Any]], None]): The drawer function to set.
         """
         pass
 
     @abstractmethod
-    def get_drawer(self) -> Callable | None:
+    def get_drawer(self) -> Optional[Callable[["IContext", Dict[str, Any]], None]]:
         """
         Get the drawer function of the artist.
 
         Returns:
-            Callable | None: The current drawer function, or None if not set.
+            Optional[Callable[[IContext, Dict[str, Any]], None]]: The current drawer function, or None if not set.
         """
         pass
 
@@ -123,5 +122,27 @@ class IArtist(ABC):
     def draw(self) -> None:
         """
         Draw the artist immediately.
+        """
+        pass
+    
+    @property
+    @abstractmethod
+    def layer_dirty(self) -> bool:
+        """
+        Check if the layer is dirty.
+
+        Returns:
+            bool: True if the layer is dirty, False otherwise.
+        """
+        pass
+
+    @layer_dirty.setter
+    @abstractmethod
+    def layer_dirty(self, value: bool) -> None:
+        """
+        Set the layer dirty state.
+
+        Args:
+            value (bool): The dirty state to set.
         """
         pass

--- a/gamms/typing/context.py
+++ b/gamms/typing/context.py
@@ -1,13 +1,12 @@
 from abc import ABC, abstractmethod
-from gamms.typing import (
-    IInternalContext,
-    ISensorEngine,
-    IVisualizationEngine,
-    IAgentEngine,
-    IGraphEngine,
-    IRecorder,
-    ILogger,
-)
+from gamms.typing.internal_context import IInternalContext
+from gamms.typing.sensor_engine import ISensorEngine
+from gamms.typing.visualization_engine import IVisualizationEngine
+from gamms.typing.agent_engine import IAgentEngine
+from gamms.typing.graph_engine import IGraphEngine
+from gamms.typing.recorder import IRecorder
+from gamms.typing.logger import ILogger
+
 
 class IContext(ABC):
     """
@@ -141,5 +140,32 @@ class IContext(ABC):
 
         Raises:
             RuntimeError: If the logger engine is not properly initialized.
+        """
+        pass
+
+    @abstractmethod
+    def is_terminated(self) -> bool:
+        """
+        Check if the context is terminated.
+
+        This method determines whether the context has been terminated, indicating
+        that no further operations should be performed.
+
+        Returns:
+            bool: True if the context is terminated, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def terminate(self) -> None:
+        """
+        Terminate the context.
+
+        This method performs necessary cleanup operations and releases resources
+        associated with the context. It should be called when the context is no
+        longer needed.
+
+        Raises:
+            RuntimeError: If the termination process encounters an error.
         """
         pass

--- a/gamms/typing/graph_engine.py
+++ b/gamms/typing/graph_engine.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Iterator
 from dataclasses import dataclass
+from shapely.geometry import LineString
+import networkx as nx
 
 @dataclass
 class Node:
@@ -27,14 +29,14 @@ class OSMEdge:
         source (int): The ID of the source node.
         target (int): The ID of the target node.
         length (float): The length of the edge.
-        linestring (List[Tuple[float, float]], optional): A list of (x, y) tuples representing the geometry of the edge.
+        linestring (LineString): The geometry of the edge represented as a LineString.
             Defaults to None.
     """
     id: int
     source: int  # Node ID
     target: int  # Node ID
     length: float
-    linestring: List[Tuple[float, float]] = None
+    linestring: LineString
 
 
 class IGraph(ABC):
@@ -81,22 +83,22 @@ class IGraph(ABC):
         pass
 
     @abstractmethod
-    def get_nodes(self) -> List[int]:
+    def get_nodes(self) -> Iterator[int]:
         """
-        Retrieve a list of all node IDs in the graph.
+        Creates an iterator of node IDs in the graph.
 
         Returns:
-            List[int]: A list containing the IDs of all nodes.
+            Iterator[int]: An iterator that yields node IDs.
         """
         pass
 
     @abstractmethod
-    def get_edges(self) -> Dict[int, OSMEdge]:
+    def get_edges(self) -> Iterator[int]:
         """
-        Retrieve a list of all edge IDs in the graph.
+        Creates an iterator of edge IDs in the graph.
 
         Returns:
-            Dict[int, OSMEdge]: A dictionary mapping edge IDs to their corresponding OSMEdge objects.
+            Iterator[int]: An iterator that yields edge IDs.
         """
         pass
 
@@ -176,7 +178,7 @@ class IGraph(ABC):
         pass
 
     @abstractmethod
-    def get_edge(self, edge_id: int) -> Dict[str, Any]:
+    def get_edge(self, edge_id: int) -> OSMEdge:
         """
         Retrieve the attributes of a specific edge.
 
@@ -184,7 +186,7 @@ class IGraph(ABC):
             edge_id (int): The unique identifier of the edge to retrieve.
 
         Returns:
-            Dict[str, Any]: A dictionary containing the edge's attributes.
+            OSMEdge: A dictionary containing the edge's attributes.
 
         Raises:
             KeyError: If the edge with the specified ID does not exist.
@@ -210,6 +212,22 @@ class IGraphEngine(ABC):
 
         Raises:
             RuntimeError: If the graph has not been initialized.
+        """
+        pass
+
+    @abstractmethod
+    def attach_networkx_graph(self, G: nx.Graph) -> IGraph:
+        """
+        Attach a NetworkX graph to the graph engine.
+
+        Args:
+            G (nx.Graph): The NetworkX graph to attach.
+        
+        Returns:
+            IGraph: The graph instance created from the NetworkX graph.
+
+        Raises:
+            ValueError: If the provided graph is invalid or cannot be attached.
         """
         pass
 

--- a/gamms/typing/recorder.py
+++ b/gamms/typing/recorder.py
@@ -1,5 +1,7 @@
-from typing import List, Union, Iterator, Dict, Type, TypeVar, Callable, BinaryIO, Tuple
+from typing import List, Union, Iterator, Dict, Type, TypeVar, Callable, BinaryIO, Tuple, Any
 from abc import ABC, abstractmethod
+
+from gamms.typing.opcodes import OpCodes
 
 JsonType = Union[None, int, str, bool, List["JsonType"], Dict[str, "JsonType"]]
 _T = TypeVar('_T')
@@ -53,7 +55,7 @@ class IRecorder(ABC):
         """
         pass
     @abstractmethod    
-    def replay(self, path: Union[str, BinaryIO]) -> Iterator:
+    def replay(self, path: Union[str, BinaryIO]) -> Iterator[Dict[str, Any]]:
         """
         Checks validity of the file and output an iterator.
 
@@ -80,7 +82,7 @@ class IRecorder(ABC):
         """
         pass
     @abstractmethod
-    def write(self, opCode, data) -> None:
+    def write(self, opCode: OpCodes, data: Dict[str, JsonType]) -> None:
         """
         Write to record buffer if recording. If not recording raise error as it should not happen.
 
@@ -103,7 +105,7 @@ class IRecorder(ABC):
         pass
 
     @abstractmethod
-    def get_component(self, name: str) -> Type[_T]:
+    def get_component(self, name: str) -> object:
         """
         Get the component from the name.
 

--- a/gamms/typing/sensor_engine.py
+++ b/gamms/typing/sensor_engine.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, Union, List, Callable
 from aenum import Enum
 
 
@@ -48,6 +48,7 @@ class ISensor(ABC):
         data (Dict[str, Any]): The data collected or maintained by the sensor.
     """
 
+    @property
     @abstractmethod
     def sensor_id(self) -> str:
         """
@@ -58,6 +59,7 @@ class ISensor(ABC):
         """
         pass
 
+    @property
     @abstractmethod
     def type(self) -> SensorType:
         """
@@ -68,18 +70,20 @@ class ISensor(ABC):
         """
         pass
 
+    @property
     @abstractmethod
-    def data(self) -> Dict[str, Any]:
+    def data(self) -> Union[Dict[str, Any], List[int]]:
         """
         Get the current data maintained by the sensor.
 
         Returns:
             Dict[str, Any]: The data maintained by the sensor.
+            List[int]: A list of node identifiers for the NEIGHBOR sensor type.
         """
         pass
 
     @abstractmethod
-    def sense(self, node_id: int) -> Dict[str, Any]:
+    def sense(self, node_id: int) -> None:
         """
         Perform sensing operations for a given node.
 
@@ -88,8 +92,9 @@ class ISensor(ABC):
         Args:
             node_id (int): The unique identifier of the node to sense.
 
-        Returns:
+        Sensed Data type:
             Dict[str, Any]: A dictionary containing the sensed data.
+            Only Neigbor sensor returns a list of node ids. List[int]
 
         Raises:
             ValueError: If the provided node_id is invalid.
@@ -114,7 +119,7 @@ class ISensor(ABC):
         pass
 
     @abstractmethod
-    def set_owner(self, owner: str) -> None:
+    def set_owner(self, owner: Union[str, None]) -> None:
         """
         Set the owner of the sensor. Owner is a string that identifies the entity responsible for the sensor.
         Used for setting the owning agent.
@@ -123,7 +128,7 @@ class ISensor(ABC):
         or management purposes.
 
         Args:
-            owner (str): The name of the owner to assign to the sensor.
+            owner (str or None): The name of the owner to assign to the sensor.
 
         Raises:
             TypeError: If the provided owner is not a string.
@@ -142,7 +147,7 @@ class ISensorEngine(ABC):
     """
 
     @abstractmethod
-    def create_sensor(self, sensor_type: SensorType, sensor_data: Dict[str, Any]) -> ISensor:
+    def create_sensor(self, sensor_id: str, sensor_type: SensorType, **kwargs: Dict[str, Any]) -> ISensor:
         """
         Create a new sensor of the specified type.
 
@@ -150,8 +155,11 @@ class ISensorEngine(ABC):
         it within the sensor engine for management.
 
         Args:
+            sensor_id (str): The unique identifier for the sensor to be created.
             sensor_type (SensorType): The type of sensor to create.
-            sensor_data (Dict[str, Any]): A dictionary containing initial data for the sensor.
+        
+        Kwargs:
+            **kwargs: Additional keyword arguments for sensor initialization.
 
         Returns:
             ISensor: The newly created sensor instance.
@@ -211,10 +219,12 @@ class ISensorEngine(ABC):
         """
         pass
 
-    def custom(self) -> None:
+    @abstractmethod
+    def custom(self, name: str) -> Callable[[ISensor], ISensor]:
         """
         Decorator for custom sensor
         For example, if the user create a new custom sensor, add a new type to SensorType enum
         and implement the new sensor class, the user can add the custom sensor to the sensor engine
         using this method.
         """
+        pass

--- a/gamms/typing/visualization_engine.py
+++ b/gamms/typing/visualization_engine.py
@@ -2,6 +2,10 @@ from gamms.typing.artist import IArtist
 from typing import Dict, Any, List, Tuple, Union
 from abc import ABC, abstractmethod
 
+ColorType = Union[
+    Tuple[Union[int, float], Union[int, float], Union[int, float]],
+    Tuple[Union[int, float], Union[int, float], Union[int, float], Union[int, float]]
+]
 
 class IVisualizationEngine(ABC):
     """

--- a/gamms/typing/visualization_engine.py
+++ b/gamms/typing/visualization_engine.py
@@ -13,7 +13,7 @@ class IVisualizationEngine(ABC):
     """
 
     @abstractmethod
-    def set_graph_visual(self, **kwargs) -> IArtist:
+    def set_graph_visual(self, **kwargs: Dict[str, Any]) -> IArtist:
         """
         Configure the visual representation of the graph.
 
@@ -37,7 +37,7 @@ class IVisualizationEngine(ABC):
         pass
 
     @abstractmethod
-    def set_agent_visual(self, agent_name: str, **kwargs) -> IArtist:
+    def set_agent_visual(self, name: str, **kwargs: Dict[str, Any]) -> IArtist:
         """
         Configure the visual representation of a specific agent.
 
@@ -45,32 +45,39 @@ class IVisualizationEngine(ABC):
         customization of how the agent is displayed within the visualization.
 
         Args:
-            agent_name (str): The unique name identifier of the agent to configure.
+            name (str): The unique name identifier of the agent to configure.
             **kwargs: Arbitrary keyword arguments representing visual settings.
                 Possible keys include:
                 - `color` (str): The color to represent the agent.
                 - `shape` (str): The shape to use for the agent's representation.
                 - `size` (float): The size of the agent in the visualization.
-                - `icon` (str): Path to an icon image to represent the agent.
-                - Additional visual parameters as needed.
-
-        Raises:
-            KeyError: If no agent with the specified `agent_name` exists.
-            ValueError: If any of the provided visual settings are invalid.
-            TypeError: If the types of the provided settings do not match expected types.
         """
         pass
 
     @abstractmethod
-    def set_sensor_visual(self, sensor_name: str, **kwargs) -> IArtist:
+    def set_sensor_visual(self, name: str, **kwargs: Dict[str, Any]) -> IArtist:
         """
         Configure the visual representation of a specific sensor.
 
+        This method sets up visual parameters for an individual sensor, allowing
+        customization of how the sensor is displayed within the visualization.
+
+        Args:
+            name (str): The unique name identifier of the sensor to configure.
+            **kwargs: Arbitrary keyword arguments representing visual settings.
+                Possible keys include:
+                - `color` (str): The color to represent the sensor.
+                - `shape` (str): The shape to use for the sensor's representation.
+                - `size` (float): The size of the sensor in the visualization.
+        
+        Raises:
+            KeyError: If the sensor with the specified name does not exist.
+            ValueError: If the sensor type is not supported for default visualization.        
         """
         pass
 
     @abstractmethod
-    def add_artist(self, name: str, artist: Union[IArtist, dict]) -> IArtist | None:
+    def add_artist(self, name: str, artist: Union[IArtist, Dict[str, Any]]) -> IArtist:
         """
         Add a custom artist or object to the visualization.
 
@@ -158,7 +165,7 @@ class IVisualizationEngine(ABC):
         pass
 
     @abstractmethod
-    def render_circle(self, x: float, y: float, radius: float, color: tuple, perform_culling_test: bool):
+    def render_circle(self, x: float, y: float, radius: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]], perform_culling_test: bool):
         """
         Render a circle shape at the specified position with the given radius and color.
 
@@ -166,13 +173,13 @@ class IVisualizationEngine(ABC):
             x (float): The x-coordinate of the circle's center.
             y (float): The y-coordinate of the circle's center.
             radius (float): The radius of the circle.
-            color (tuple): The color of the circle in RGB format.
+            color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the circle in RGB format.
             perform_culling_test (bool): Whether to perform culling.
         """
         pass
 
     @abstractmethod
-    def render_rectangle(self, x: float, y: float, width: float, height: float, color: tuple, perform_culling_test: bool):
+    def render_rectangle(self, x: float, y: float, width: float, height: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]], perform_culling_test: bool):
         """
         Render a rectangle shape at the specified position with the given dimensions and color.
 
@@ -181,13 +188,13 @@ class IVisualizationEngine(ABC):
             y (float): The y-coordinate of the rectangle's center.
             width (float): The width of the rectangle.
             height (float): The height of the rectangle.
-            color (tuple): The color of the rectangle in RGB format.
+            color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the rectangle in RGB format.
             perform_culling_test (bool): Whether to perform culling.
         """
         pass
 
     @abstractmethod
-    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: tuple, width: int, is_aa: bool, perform_culling_test: bool):
+    def render_line(self, start_x: float, start_y: float, end_x: float, end_y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]], width: int, is_aa: bool, perform_culling_test: bool):
         """
         Render a line segment between two points with the specified color and width.
 
@@ -196,7 +203,7 @@ class IVisualizationEngine(ABC):
             start_y (float): The y-coordinate of the starting point.
             end_x (float): The x-coordinate of the ending point.
             end_y (float): The y-coordinate of the ending point.
-            color (tuple): The color of the line in RGB format.
+            color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the line in RGB format.
             width (int): The width of the line in pixels. Only non-antialiasing lines supports width.
             is_aa (bool): Whether to use antialiasing for smoother rendering.
             perform_culling_test (bool): Whether to perform culling.
@@ -204,13 +211,13 @@ class IVisualizationEngine(ABC):
         pass
 
     @abstractmethod
-    def render_linestring(self, points: List[Tuple[float, float]], color: tuple, width: int, closed: bool, is_aa: bool, perform_culling_test: bool):
+    def render_linestring(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]], width: int, closed: bool, is_aa: bool, perform_culling_test: bool):
         """
         Render a series of connected line segments between multiple points.
 
         Args:
-            points (list[tuple[float, float]]): A list of (x, y) coordinate tuples defining the line segments.
-            color (tuple): The color of the lines in RGB format.
+            points (list[Tuple[float, float]]): A list of (x, y) coordinate tuples defining the line segments.
+            color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the lines in RGB format.
             width (int): The width of the lines in pixels. Only non-antialiasing lines supports width.
             closed (bool): Whether the line segments form a closed shape.
             is_aa (bool): Whether to use antialiasing for smoother rendering.
@@ -219,21 +226,21 @@ class IVisualizationEngine(ABC):
         pass
 
     @abstractmethod
-    def render_polygon(self, points: List[Tuple[float, float]], color: tuple, width: int,
-                       perform_culling_test: bool = True):
+    def render_polygon(self, points: List[Tuple[float, float]], color: Tuple[Union[int, float], Union[int, float], Union[int, float]], width: int,
+                       perform_culling_test: bool):
         """
         Render a polygon shape or outline defined by a list of vertices with the specified color and width.
 
         Args:
-            points (list[tuple[float, float]]): A list of (x, y) coordinate tuples defining the polygon vertices.
-            color (tuple): The color of the polygon in RGB format.
+            points (list[Tuple[float, float]]): A list of (x, y) coordinate tuples defining the polygon vertices.
+            color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the polygon in RGB format.
             width (int): The width of the polygon outline in pixels. If equal to 0, the polygon is filled.
             perform_culling_test (bool): Whether to perform culling.
         """
         pass
 
     @abstractmethod
-    def render_text(self, text: str, x: float, y: float, color: tuple, perform_culling_test: bool):
+    def render_text(self, text: str, x: float, y: float, color: Tuple[Union[int, float], Union[int, float], Union[int, float]], perform_culling_test: bool):
         """
         Render text at the specified position with the given content and color.
 
@@ -241,7 +248,17 @@ class IVisualizationEngine(ABC):
             text (str): The text content to display.
             x (float): The x-coordinate of the text's center position.
             y (float): The y-coordinate of the text's center position.
-            color (tuple): The color of the text in RGB format.
+            color (Tuple[Union[int, float], Union[int, float], Union[int, float]]): The color of the text in RGB format.
             perform_culling_test (bool): Whether to perform culling.
+        """
+        pass
+
+    @abstractmethod
+    def render_layer(self, layer_id: int) -> None:
+        """
+        Render the specified layer of the visualization.
+
+        Args:
+            layer_id (int): The layer number to render.
         """
         pass

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
         'pygame',
         'shapely',
         'networkx',
-        'py-ubjson',
-        'aenum'
+        'cbor2',
+        'aenum',
+        'osmnx',
     ],
 )        

--- a/tests/recorder_test.py
+++ b/tests/recorder_test.py
@@ -1,5 +1,4 @@
 import unittest
-from gamms.typing.opcodes import OpCodes
 import gamms
 import io
 
@@ -66,8 +65,8 @@ class RecorderTest(unittest.TestCase):
         self.ctx.agent.delete_agent('agent_0')
         self.ctx.agent.delete_agent('agent_1')
         # Check if the agents are removed
-        self.assertRaises(ValueError, self.ctx.agent.get_agent, 'agent_0')
-        self.assertRaises(ValueError, self.ctx.agent.get_agent, 'agent_1')
+        self.assertRaises(KeyError, self.ctx.agent.get_agent, 'agent_0')
+        self.assertRaises(KeyError, self.ctx.agent.get_agent, 'agent_1')
 
         # Remove the component
         self.ctx.record.delete_component('test')


### PR DESCRIPTION
This is a huge PR to correct for the graph api that was in the original design. The following changes have been made:
- Graph API change and dependency changes
- Updates in typing and changes to account for python backward compatibility
- Shifted from ubjson to CBOR as it is a more stable specification with RFCs

## Graph API Changes

The graph api for `get_nodes` and `get_edges` was supposed to return only the IDs for both and not the objects themselves. The original API was made to ease development of future implementation of the memory engine to use a database-like backend. The double fetch can be used to optimize the queries as well as make it more flexible as the type of the return for the API is always fixed. It is more intensive to *load* all edges in place of loading only a few specific edges. Same goes for nodes. Right now, everything is in memory but this will not be true for larger graphs.

With that change, everything from sensors to artists needed to be changed for everything to work.

## Typing updates

The direct annotations like `tuple` `dict` are loose and also can be confused with real operations. The explicit typing via `typing` library is friendlier with other libraries and its easier to do type checks. This also makes everything compatible with older versions of python.

This is by far the largest change affecting almost all files.

There were also mismatches in the gamms typing definitions and the actual implementations which have been resolved to a large extent.

## Recording Changes

Shifted from ubjson format to cbor which is more compressed than ubjson and have support from a larger community.

## Unresolved things

This is not exhaustive. The typing issues in recorder are difficult to resolve as it relies on some *python magic* which is not technically type strict.

Typing needs to be extended to create object level (say for each sensor) documentation and needs to be organized in the documentation.