### PR TITLE
Sqlite graph

### DIFF
--- a/gamms/AgentEngine/agent_engine.py
+++ b/gamms/AgentEngine/agent_engine.py
@@ -245,7 +245,7 @@ class AgentEngine(IAgentEngine):
 
     def delete_agent(self, name: str) -> None:
         if self.ctx.record.record():
-            self.ctx.record.write(opCode=OpCodes.AGENT_DELETE, data=name)
+            self.ctx.record.write(opCode=OpCodes.AGENT_DELETE, data={'name' :name})
             
         if name not in self.agents:
             self.ctx.logger.warning(f"Deleting non-existent agent {name}")

--- a/gamms/GraphEngine/__init__.py
+++ b/gamms/GraphEngine/__init__.py
@@ -1,0 +1,1 @@
+from gamms.typing.graph_engine import Engine

--- a/gamms/GraphEngine/graph_engine.py
+++ b/gamms/GraphEngine/graph_engine.py
@@ -4,7 +4,10 @@ from gamms.typing import Node, OSMEdge, IGraph, IGraphEngine, IContext
 import pickle
 from shapely.geometry import LineString
 
-# TODO: Remove LineString dependency
+import sqlite3
+
+import tempfile
+import cbor2
 
 class Graph(IGraph):
     def __init__(self):
@@ -145,6 +148,198 @@ class Graph(IGraph):
         self.nodes = data['nodes']
         self.edges = data['edges']
 
+
+class SqliteGraph(IGraph):
+    def __init__(self, ctx: IContext):
+        self.ctx = ctx
+        # Create a random name for the SQLite database
+        self._dbfile = tempfile.NamedTemporaryFile(dir="./", suffix=".sqlite")
+        self._conn = sqlite3.connect(self._dbfile.name)
+        self._cursor = self._conn.cursor()
+        self.node_store = self._cursor.execute(
+            "CREATE TABLE IF NOT EXISTS nodes (id INTEGER PRIMARY KEY, x REAL, y REAL)"
+        )
+        # Create index on node x,y for faster lookups
+        self._cursor.execute("CREATE INDEX IF NOT EXISTS idx_nodes_xy ON nodes (x, y)")
+        self.edge_store = self._cursor.execute(
+            "CREATE TABLE IF NOT EXISTS edges (id INTEGER PRIMARY KEY, source INTEGER, target INTEGER, length REAL, geom BLOB, FOREIGN KEY(source) REFERENCES nodes(id), FOREIGN KEY(target) REFERENCES nodes(id))"
+        )
+        # Create index on edge source,target for faster lookups
+        self._cursor.execute("CREATE INDEX IF NOT EXISTS idx_edges_source_target ON edges (source, target)")
+        self._conn.commit()
+        self._call_commit = False
+    
+    def __del__(self):
+        """
+        Destructor to close the database connection.
+        """
+        self._conn.close()
+        if self._dbfile:
+            try:
+                self._dbfile.close()
+            except Exception as e:
+                print(f"Error closing temporary file: {e}")        
+    
+    def add_node(self, node_data: Dict[str, Any]) -> None:
+        """
+        Adds a node to the graph.
+        """
+        if 'id' not in node_data or 'x' not in node_data or 'y' not in node_data:
+            raise ValueError("Node data must include 'id', 'x', and 'y'.")
+        
+        self._cursor.execute("INSERT INTO nodes (id, x, y) VALUES (?, ?, ?)", 
+                       (node_data['id'], node_data['x'], node_data['y']))
+        
+        self._call_commit = True
+    
+    def add_edge(self, edge_data: Dict[str, Any]) -> None:
+        """
+        Adds an edge to the graph.
+        """
+        if 'id' not in edge_data or 'source' not in edge_data or 'target' not in edge_data or 'length' not in edge_data:
+            raise ValueError("Edge data must include 'id', 'source', 'target', and 'length'.")
+        
+        linestring = edge_data.get('linestring', None)
+        if linestring is None:
+            # Create a LineString from the source and target node coordinates
+            source_node = self.get_node(edge_data['source'])
+            target_node = self.get_node(edge_data['target'])
+            linestring = ((source_node.x, source_node.y), (target_node.x, target_node.y))
+        elif not isinstance(linestring, LineString):
+            try:
+                linestring = LineString(linestring)
+                linestring = tuple(linestring.coords)
+            except Exception as e:
+                raise ValueError(f"Invalid linestring data: {linestring}") from e
+        else:
+            linestring = tuple(linestring.coords)
+
+        self._cursor.execute("INSERT INTO edges (id, source, target, length, geom) VALUES (?, ?, ?, ?, ?)",
+                       (edge_data['id'], edge_data['source'], edge_data['target'], edge_data['length'], cbor2.dumps(linestring)))
+
+        self._call_commit = True
+    
+    def get_node(self, node_id: int) -> Node:
+        """
+        Retrieves a node by its ID.
+        """
+        if self._call_commit:
+            self._conn.commit()
+            self._call_commit = False
+        cursor = self._conn.cursor()
+        cursor.execute("SELECT id, x, y FROM nodes WHERE id = ?", (node_id,))
+        row = cursor.fetchone()
+        if row is None:
+            raise KeyError(f"Node {node_id} does not exist.")
+        
+        return Node(id=row[0], x=row[1], y=row[2])
+    
+    def get_edges(self) -> Iterator[int]:
+        """
+        Returns an iterator over all edge IDs in the graph.
+        """
+        if self._call_commit:
+            self._conn.commit()
+            self._call_commit = False
+        cursor = self._conn.cursor()
+        cursor.execute("SELECT id FROM edges")
+        while True:
+            row = cursor.fetchone()
+            if row is None:
+                break
+            yield row[0]
+    
+    def get_edge(self, edge_id: int) -> OSMEdge:
+        """
+        Retrieves an edge by its ID.
+        """
+        if self._call_commit:
+            self._conn.commit()
+            self._call_commit = False
+        cursor = self._conn.cursor()
+        cursor.execute("SELECT id, source, target, length, geom FROM edges WHERE id = ?", (edge_id,))
+        row = cursor.fetchone()
+        if row is None:
+            raise KeyError(f"Edge {edge_id} does not exist.")
+        
+        return OSMEdge(id=row[0], source=row[1], target=row[2], length=row[3], linestring=LineString(cbor2.loads(row[4])))
+    
+    def get_nodes(self) -> Iterator[int]:
+        """
+        Returns an iterator over all node IDs in the graph.
+        """
+        if self._call_commit:
+            self._conn.commit()
+            self._call_commit = False
+        cursor = self._conn.cursor()
+        cursor.execute("SELECT id FROM nodes")
+        while True:
+            row = cursor.fetchone()
+            if row is None:
+                break
+            yield row[0]
+    
+    def update_node(self, node_data: Dict[str, Any]) -> None:
+        """
+        Updates a node in the graph.
+        """
+        if 'id' not in node_data or 'x' not in node_data or 'y' not in node_data:
+            raise ValueError("Node data must include 'id', 'x', and 'y'.")
+        
+        _ = self.get_node(node_data['id'])
+        
+        self._cursor.execute("UPDATE nodes SET x = ?, y = ? WHERE id = ?", 
+                       (node_data['x'], node_data['y'], node_data['id']))
+        
+        self._call_commit = True
+    
+    def update_edge(self, edge_data: Dict[str, Any]) -> None:
+        """
+        Updates an edge in the graph.
+        """
+        if 'id' not in edge_data or 'source' not in edge_data or 'target' not in edge_data or 'length' not in edge_data:
+            raise ValueError("Edge data must include 'id', 'source', 'target', and 'length'.")
+        
+        _ = self.get_edge(edge_data['id'])
+        
+        linestring = edge_data.get('linestring', None)
+        if linestring is None:
+            # Create a LineString from the source and target node coordinates
+            source_node = self.get_node(edge_data['source'])
+            target_node = self.get_node(edge_data['target'])
+            linestring = ((source_node.x, source_node.y), (target_node.x, target_node.y))
+        elif not isinstance(linestring, LineString):
+            try:
+                linestring = LineString(linestring)
+                linestring = tuple(linestring.coords)
+            except Exception as e:
+                raise ValueError(f"Invalid linestring data: {linestring}") from e
+        else:
+            linestring = tuple(linestring.coords)
+        
+        self._cursor.execute("UPDATE edges SET source = ?, target = ?, length = ?, geom = ? WHERE id = ?",
+                       (edge_data['source'], edge_data['target'], edge_data['length'], cbor2.dumps(linestring), edge_data['id']))
+        
+        self._call_commit = True
+    
+    def remove_node(self, node_id: int) -> None:
+        """
+        Removes a node from the graph.
+        """
+        self._cursor.execute("DELETE FROM nodes WHERE id = ?", (node_id,))
+        
+        # Remove edges associated with this node
+        self._cursor.execute("DELETE FROM edges WHERE source = ? OR target = ?", (node_id, node_id))
+        
+        self._call_commit = True
+    
+    def remove_edge(self, edge_id: int) -> None:
+        """
+        Removes an edge from the graph.
+        """
+        self._cursor.execute("DELETE FROM edges WHERE id = ?", (edge_id,))
+        
+        self._call_commit = True
 
 class GraphEngine(IGraphEngine):
     def __init__(self, ctx: IContext):

--- a/gamms/GraphEngine/graph_engine.py
+++ b/gamms/GraphEngine/graph_engine.py
@@ -339,7 +339,7 @@ class SqliteGraph(IGraph):
             self._call_commit = False
         cursor = self._conn.cursor()
         if d >= 0:
-            cursor.execute("SELECT id FROM nodes WHERE ABS(x - ?) <= ? AND ABS(y - ?) <= ?", (x, d, y, d))
+            cursor.execute("SELECT id FROM nodes WHERE x BETWEEN ? AND ? AND y BETWEEN ? AND ?", (x - d, x + d, y - d, y + d))
         else:
             cursor.execute("SELECT id FROM nodes")
         while True:

--- a/gamms/GraphEngine/graph_engine.py
+++ b/gamms/GraphEngine/graph_engine.py
@@ -1,5 +1,6 @@
 import networkx as nx
 from typing import Dict, Any, Iterator, cast, Union, Set, overload
+from enum import Enum
 from gamms.typing import Node, OSMEdge, IGraph, IGraphEngine, IContext
 from gamms.typing.graph_engine import Engine
 import pickle
@@ -279,7 +280,7 @@ class SqliteGraph(IGraph):
             self._call_commit = False
         cursor = self._conn.cursor()
         if d >= 0:
-            cursor.execute("SELECT id FROM edges JOIN nodes AS u ON edges.source = u.id JOIN nodes AS v ON edges.target = v.id WHERE (ABS(u.x - ?) <= ? AND ABS(u.y - ?) <= ?) OR (ABS(v.x - ?) <= ? AND ABS(v.y - ?) <= ?)",
+            cursor.execute("SELECT edges.id FROM edges JOIN nodes AS u ON edges.source = u.id JOIN nodes AS v ON edges.target = v.id WHERE (ABS(u.x - ?) <= ? AND ABS(u.y - ?) <= ?) OR (ABS(v.x - ?) <= ? AND ABS(v.y - ?) <= ?)",
                            (x, d, y, d, x, d, y, d))
         else:
             cursor.execute("SELECT id FROM edges")
@@ -443,7 +444,7 @@ class SqliteGraph(IGraph):
             yield row[0]
 
 class GraphEngine(IGraphEngine):
-    def __init__(self, ctx: IContext, engine: Engine = Engine.SQLITE):
+    def __init__(self, ctx: IContext, engine: Enum = Engine.SQLITE):
         if engine == Engine.MEMORY:
             self._graph = Graph()
         elif engine == Engine.SQLITE:
@@ -451,7 +452,6 @@ class GraphEngine(IGraphEngine):
         else:
             raise ValueError(f"Unsupported engine type: {engine}")
         self.ctx = ctx
-        self._graph = Graph()
     
     @property
     def graph(self) -> IGraph:

--- a/gamms/GraphEngine/graph_engine.py
+++ b/gamms/GraphEngine/graph_engine.py
@@ -217,10 +217,7 @@ class SqliteGraph(IGraph):
         """
         self._conn.close()
         if self._dbfile:
-            try:
-                self._dbfile.close()
-            except Exception as e:
-                self.ctx.logger.error(f"Error closing temporary file: {e}")        
+            self._dbfile.close()
     
     def add_node(self, node_data: Dict[str, Any]) -> None:
         """

--- a/gamms/GraphEngine/graph_engine.py
+++ b/gamms/GraphEngine/graph_engine.py
@@ -299,8 +299,10 @@ class SqliteGraph(IGraph):
             self._call_commit = False
         cursor = self._conn.cursor()
         if d >= 0:
-            cursor.execute("SELECT edges.id FROM edges JOIN nodes AS u ON edges.source = u.id JOIN nodes AS v ON edges.target = v.id WHERE (ABS(u.x - ?) <= ? AND ABS(u.y - ?) <= ?) OR (ABS(v.x - ?) <= ? AND ABS(v.y - ?) <= ?)",
-                           (x, d, y, d, x, d, y, d))
+            x_min, x_max = x - d, x + d
+            y_min, y_max = y - d, y + d
+            cursor.execute("SELECT edges.id FROM edges JOIN nodes AS u ON edges.source = u.id JOIN nodes AS v ON edges.target = v.id WHERE (u.x BETWEEN ? AND ? AND u.y BETWEEN ? AND ?) OR (v.x BETWEEN ? AND ? AND v.y BETWEEN ? AND ?)",
+                           (x_min, x_max, y_min, y_max, x_min, x_max, y_min, y_max))
         else:
             cursor.execute("SELECT id FROM edges")
         while True:

--- a/gamms/GraphEngine/graph_engine.py
+++ b/gamms/GraphEngine/graph_engine.py
@@ -220,7 +220,7 @@ class SqliteGraph(IGraph):
             try:
                 self._dbfile.close()
             except Exception as e:
-                print(f"Error closing temporary file: {e}")        
+                self.ctx.logger.error(f"Error closing temporary file: {e}")        
     
     def add_node(self, node_data: Dict[str, Any]) -> None:
         """

--- a/gamms/Recorder/recorder.py
+++ b/gamms/Recorder/recorder.py
@@ -27,7 +27,7 @@ def _record_switch_case(ctx: IContext, opCode: OpCodes, data: JsonType) -> None:
         ctx.agent.create_agent(data["name"], **data["kwargs"])
     elif opCode == OpCodes.AGENT_DELETE:
         ctx.logger.info(f"Deleting agent {data['name']}")
-        ctx.agent.delete_agent(data)
+        ctx.agent.delete_agent(data['name'])
     elif opCode == OpCodes.SIMULATE:
         ctx.visual.simulate()
     elif opCode == OpCodes.AGENT_CURRENT_NODE:

--- a/gamms/SensorEngine/sensor_engine.py
+++ b/gamms/SensorEngine/sensor_engine.py
@@ -114,13 +114,17 @@ class MapSensor(ISensor):
             sbool = (source.x - current_node.x)**2 + (source.y - current_node.y)**2 <= self.range**2
             tbool = (target.x - current_node.x)**2 + (target.y - current_node.y)**2 <= self.range**2
             if not (self.fov == 2 * math.pi or orientation_used == (0.0, 0.0)):
+                angle = math.atan2(current_node.y - source.y, current_node.x - source.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                angle = angle % (2 * math.pi)
+                angle = angle - math.pi
                 sbool &= (
-                    abs(math.atan2(source.y - current_node.y, source.x - current_node.x) - 
-                        math.atan2(orientation_used[1], orientation_used[0])) <= self.fov / 2
+                    abs(angle) <= self.fov / 2
                 )
+                angle = math.atan2(current_node.y - target.y, current_node.x - target.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                angle = angle % (2 * math.pi)
+                angle = angle - math.pi
                 tbool &= (
-                    abs(math.atan2(target.y - current_node.y, target.x - current_node.x) - 
-                        math.atan2(orientation_used[1], orientation_used[0])) <= self.fov / 2
+                    abs(angle) <= self.fov / 2
                 )
             if sbool:
                 sensed_nodes[source.id] = source
@@ -219,8 +223,10 @@ class AgentSensor(ISensor):
                 if self.fov == 2 * math.pi or orientation_used == (0.0, 0.0):
                     sensed_agents[agent.name] = agent.current_node_id
                 else:
-                    angle = math.atan2(agent_node.y - current_node.y, agent_node.x - current_node.x)
-                    if abs(angle - math.atan2(orientation_used[1], orientation_used[0])) <= self.fov / 2:
+                    angle = math.atan2(agent_node.y - current_node.y, agent_node.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                    angle = angle % (2 * math.pi)
+                    angle = angle - math.pi
+                    if abs(angle) <= self.fov / 2:
                         sensed_agents[agent.name] = agent.current_node_id
 
         self._data = sensed_agents

--- a/gamms/SensorEngine/sensor_engine.py
+++ b/gamms/SensorEngine/sensor_engine.py
@@ -223,7 +223,7 @@ class AgentSensor(ISensor):
                 if self.fov == 2 * math.pi or orientation_used == (0.0, 0.0):
                     sensed_agents[agent.name] = agent.current_node_id
                 else:
-                    angle = math.atan2(current_node.y - agent_node.y, current_node.x - agent_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                    angle = math.atan2(agent_node.y - current_node.y, agent_node.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
                     angle = angle % (2 * math.pi)
                     angle = angle - math.pi
                     if abs(angle) <= self.fov / 2:

--- a/gamms/SensorEngine/sensor_engine.py
+++ b/gamms/SensorEngine/sensor_engine.py
@@ -37,11 +37,9 @@ class NeighborSensor(ISensor):
 
     def sense(self, node_id: int) -> None:
         nearest_neighbors = {node_id,}
-        for edge_id in self.ctx.graph.graph.get_edges():
-            edge = self.ctx.graph.graph.get_edge(edge_id)
-            if edge.source == node_id:
-                nearest_neighbors.add(edge.target)
-                        
+        for nid in self.ctx.graph.graph.get_neighbors(node_id):
+            nearest_neighbors.add(nid)
+
         self._data = list(nearest_neighbors)
 
     def update(self, data: Dict[str, Any]) -> None:

--- a/gamms/SensorEngine/sensor_engine.py
+++ b/gamms/SensorEngine/sensor_engine.py
@@ -10,7 +10,6 @@ from gamms.typing import(
 from typing import Any, Dict, Optional, Callable, Tuple, List, Union, cast
 from aenum import extend_enum
 import math
-import numpy as np
 
 class NeighborSensor(ISensor):
     def __init__(self, ctx: IContext, sensor_id: str, sensor_type: SensorType):
@@ -62,9 +61,6 @@ class MapSensor(ISensor):
         self.orientation = (orientation[0] / norm, orientation[1] / norm)
         self._data: Dict[str, Union[Dict[int, Node], List[OSMEdge]]] = {}
         # Cache static node IDs and positions.
-        self.nodes = cast(Dict[int, Node], self.ctx.graph.graph.nodes)
-        self.node_ids: List[int] = list(self.nodes.keys())
-        self._positions = np.array([[self.nodes[nid].x, self.nodes[nid].y] for nid in self.node_ids], dtype=np.float32)
         self._owner = None
     
     @property
@@ -90,8 +86,7 @@ class MapSensor(ISensor):
           - 'nodes': {node_id: node, ...} for nodes that pass the sensing filter.
           - 'edges': List of edges visible from all sensed nodes.
         """
-        current_node = self.nodes[node_id]
-        current_position = np.array([current_node.x, current_node.y]).reshape(1, 2)
+        current_node = self.ctx.graph.graph.get_node(node_id)
         if self._owner is not None:
             # Fetch the owner's orientation from the agent engine.
             orientation_used = self.ctx.agent.get_agent(self._owner).orientation
@@ -102,36 +97,36 @@ class MapSensor(ISensor):
             )
         else:
             orientation_used = self.orientation
-
-        diff = self._positions - current_position
-        distances_sq = np.sum(diff**2, axis=1)
+        
         if self.range == float('inf'):
-            in_range_mask = np.full(distances_sq.shape, True)
+            edge_iter = self.ctx.graph.graph.get_edges()
         else:
-            in_range_mask = distances_sq <= self.range**2
-        in_range_indices = np.nonzero(in_range_mask)[0]
+            edge_iter = self.ctx.graph.graph.get_edges(d=self.range, x=current_node.x, y=current_node.y)
+
 
         sensed_nodes: Dict[int, Node] = {}
-        if in_range_indices.size:
-            if self.fov == 2 * math.pi or orientation_used == (0.0, 0.0):
-                valid_indices = in_range_indices
-            else:
-                orientation_used = np.atan2(orientation_used[1], orientation_used[0]) % (2 * math.pi)
-                diff_in_range = diff[in_range_indices]
-                angles = np.arctan2(diff_in_range[:, 1], diff_in_range[:, 0]) % (2 * math.pi)
-                angle_diff = np.abs((angles - orientation_used + math.pi) % (2 * math.pi) - math.pi)
-                valid_mask = angle_diff <= (self.fov / 2)
-                valid_indices = in_range_indices[valid_mask]
-            sensed_nodes = {self.node_ids[i]: self.nodes[self.node_ids[i]] for i in valid_indices}
-        
-        sensed_nodes[node_id] = current_node
-
-        # Now, compute the connecting edges from the sensing node to each sensed node.
         sensed_edges: List[OSMEdge] = []
-        # Retrieve edges from the graph via the context's graph engine.
-        graph_edges = cast(Dict[int, OSMEdge], self.ctx.graph.graph.edges)
-        for edge in graph_edges.values():
-            if edge.source in sensed_nodes and edge.target in sensed_nodes:
+
+        for edge_id in edge_iter:
+            edge = self.ctx.graph.graph.get_edge(edge_id)
+            source = self.ctx.graph.graph.get_node(edge.source)
+            target = self.ctx.graph.graph.get_node(edge.target)
+            sbool = (source.x - current_node.x)**2 + (source.y - current_node.y)**2 <= self.range**2
+            tbool = (target.x - current_node.x)**2 + (target.y - current_node.y)**2 <= self.range**2
+            if not (self.fov == 2 * math.pi or orientation_used == (0.0, 0.0)):
+                sbool &= (
+                    abs(math.atan2(source.y - current_node.y, source.x - current_node.x) - 
+                        math.atan2(orientation_used[1], orientation_used[0])) <= self.fov / 2
+                )
+                tbool &= (
+                    abs(math.atan2(target.y - current_node.y, target.x - current_node.x) - 
+                        math.atan2(orientation_used[1], orientation_used[0])) <= self.fov / 2
+                )
+            if sbool:
+                sensed_nodes[source.id] = source
+            if tbool:
+                sensed_nodes[target.id] = target
+            if sbool and tbool:
                 sensed_edges.append(edge)
 
         self._data = {'nodes': sensed_nodes, 'edges': sensed_edges}
@@ -198,59 +193,35 @@ class AgentSensor(ISensor):
         """
         # Get current node position as sensing origin.
         current_node = self.ctx.graph.graph.get_node(node_id)
-        current_position = np.array([current_node.x, current_node.y]).reshape(1, 2)
 
-        agents = list(self.ctx.agent.create_iter())
+        if self._owner is not None:
+            # Fetch the owner's orientation from the agent engine.
+            orientation_used = self.ctx.agent.get_agent(self._owner).orientation
+            # Complex multiplication to rotate the orientation vector.
+            orientation_used = (
+                self.orientation[0]*orientation_used[0] - self.orientation[1]*orientation_used[1], 
+                self.orientation[0]*orientation_used[1] + self.orientation[1]*orientation_used[0]
+            )
+        else:
+            orientation_used = self.orientation
+
         sensed_agents = {}
-        agent_ids: List[str] = []
-        agent_positions = []
 
         # Collect positions and ids for all agents except the owner.
-        for agent in agents:
-            if self._owner is not None and agent.name == self._owner:
+        for agent in self.ctx.agent.create_iter():
+            if agent.name == self._owner:
                 continue
-            agent_ids.append(agent.name)
-            if hasattr(agent, 'position'):
-                pos = np.array(agent.position)
-            else:
-                node_obj = self.ctx.graph.graph.get_node(agent.current_node_id)
-                pos = np.array([node_obj.x, node_obj.y])
-            agent_positions.append(pos)
-
-        if agent_positions:
-            agent_positions = np.array(agent_positions).reshape(-1, 2)
-            diff_agents = agent_positions - current_position
-            distances_agents_sq = np.sum(diff_agents**2, axis=1)
-            in_range_mask = distances_agents_sq <= self.range**2
-            in_range_indices = np.nonzero(in_range_mask)[0]
-
-            if self._owner is not None:
-                # Fetch the owner's orientation from the agent engine.
-                orientation_used = self.ctx.agent.get_agent(self._owner).orientation
-                # Complex multiplication to rotate the orientation vector.
-                orientation_used = (
-                    self.orientation[0]*orientation_used[0] - self.orientation[1]*orientation_used[1], 
-                    self.orientation[0]*orientation_used[1] + self.orientation[1]*orientation_used[0]
-                )
-            else:
-                orientation_used = self.orientation
-
-            if self.fov == 2 * math.pi or orientation_used == (0.0, 0.0):
-                valid_indices = in_range_indices
-            else:
-                orientation_used = np.arctan2(orientation_used[1], orientation_used[0]) % (2 * math.pi)
-                diff_in_range = diff_agents[in_range_indices]
-                angles = np.arctan2(diff_in_range[:, 1], diff_in_range[:, 0]) % (2 * math.pi)
-                angle_diff = np.abs((angles - orientation_used + math.pi) % (2 * math.pi) - math.pi)
-                valid_mask = angle_diff <= (self.fov / 2)
-                valid_indices = in_range_indices[valid_mask]
-
-            in_range_agent_ids = {agent_ids[i] for i in valid_indices}
-            for agent in agents:
-                if self._owner is not None and agent.name == self._owner:
-                    continue
-                if agent.name in in_range_agent_ids:
+            
+            agent_node = self.ctx.graph.graph.get_node(agent.current_node_id)
+            distance = (agent_node.x - current_node.x)**2 + (agent_node.y - current_node.y)**2
+            
+            if distance <= self.range**2:
+                if self.fov == 2 * math.pi or orientation_used == (0.0, 0.0):
                     sensed_agents[agent.name] = agent.current_node_id
+                else:
+                    angle = math.atan2(agent_node.y - current_node.y, agent_node.x - current_node.x)
+                    if abs(angle - math.atan2(orientation_used[1], orientation_used[0])) <= self.fov / 2:
+                        sensed_agents[agent.name] = agent.current_node_id
 
         self._data = sensed_agents
 

--- a/gamms/SensorEngine/sensor_engine.py
+++ b/gamms/SensorEngine/sensor_engine.py
@@ -114,13 +114,13 @@ class MapSensor(ISensor):
             sbool = (source.x - current_node.x)**2 + (source.y - current_node.y)**2 <= self.range**2
             tbool = (target.x - current_node.x)**2 + (target.y - current_node.y)**2 <= self.range**2
             if not (self.fov == 2 * math.pi or orientation_used == (0.0, 0.0)):
-                angle = math.atan2(current_node.y - source.y, current_node.x - source.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                angle = math.atan2(source.y - current_node.y, source.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
                 angle = angle % (2 * math.pi)
                 angle = angle - math.pi
                 sbool &= (
                     abs(angle) <= self.fov / 2
                 )
-                angle = math.atan2(current_node.y - target.y, current_node.x - target.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                angle = math.atan2(target.y - current_node.y, target.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
                 angle = angle % (2 * math.pi)
                 angle = angle - math.pi
                 tbool &= (

--- a/gamms/SensorEngine/sensor_engine.py
+++ b/gamms/SensorEngine/sensor_engine.py
@@ -223,7 +223,7 @@ class AgentSensor(ISensor):
                 if self.fov == 2 * math.pi or orientation_used == (0.0, 0.0):
                     sensed_agents[agent.name] = agent.current_node_id
                 else:
-                    angle = math.atan2(agent_node.y - current_node.y, agent_node.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                    angle = math.atan2(current_node.y - agent_node.y, current_node.x - agent_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
                     angle = angle % (2 * math.pi)
                     angle = angle - math.pi
                     if abs(angle) <= self.fov / 2:

--- a/gamms/__init__.py
+++ b/gamms/__init__.py
@@ -7,15 +7,17 @@ from gamms.context import Context
 from enum import Enum
 
 from gamms.typing import logger
+from typing import Dict, Any, Optional
 
 import logging
 
 import os
 
 def create_context(
+    graph_engine: Enum = graph.Engine.SQLITE,
     vis_engine: Enum = visual.Engine.NO_VIS,
-    vis_kwargs: dict = None,
-    logger_config: dict = None,
+    vis_kwargs: Optional[Dict[str, Any]] = None,
+    logger_config: Optional[Dict[str, Any]] = None,
 ) -> Context:
     _logger = logging.getLogger("gamms")
     if logger_config is None:
@@ -30,11 +32,10 @@ def create_context(
     else:
         raise NotImplementedError(f"Visualization engine {vis_engine} not implemented")
     
-    graph_engine = graph.GraphEngine(ctx)
     agent_engine = agent.AgentEngine(ctx)
     sensor_engine = sensor.SensorEngine(ctx)
     ctx.agent_engine = agent_engine
-    ctx.graph_engine = graph_engine
+    ctx.graph_engine = graph.GraphEngine(ctx, engine=graph_engine)
     ctx.visual_engine = visual_engine
     ctx.sensor_engine = sensor_engine
     ctx.recorder = Recorder(ctx)

--- a/gamms/typing/graph_engine.py
+++ b/gamms/typing/graph_engine.py
@@ -1,8 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterator
+from typing import Any, Dict, Iterator, overload
 from dataclasses import dataclass
 from shapely.geometry import LineString
 import networkx as nx
+
+from enum import Enum
+
+class Engine(Enum):
+    MEMORY = 0
+    SQLITE = 1
 
 @dataclass
 class Node:
@@ -83,6 +89,7 @@ class IGraph(ABC):
         pass
 
     @abstractmethod
+    @overload
     def get_nodes(self) -> Iterator[int]:
         """
         Creates an iterator of node IDs in the graph.
@@ -91,11 +98,41 @@ class IGraph(ABC):
             Iterator[int]: An iterator that yields node IDs.
         """
         pass
+    
+    @abstractmethod
+    @overload
+    def get_nodes(self, d: float, x: float, y: float) -> Iterator[int]:
+        """
+        Creates an iterator of node IDs in the graph.
+
+        If d is non-negative, it returns nodes within a distance d from the point (x, y).
+        May return nodes that are farther than d but will always return nodes that are within d.
+
+        Returns:
+            Iterator[int]: An iterator that yields node IDs.
+        """
+        pass
 
     @abstractmethod
+    @overload
     def get_edges(self) -> Iterator[int]:
         """
         Creates an iterator of edge IDs in the graph.
+
+        Returns:
+            Iterator[int]: An iterator that yields edge IDs.
+        """
+        pass
+
+    @abstractmethod
+    @overload
+    def get_edges(self, d: float, x: float, y: float) -> Iterator[int]:
+        """
+        Creates an iterator of edge IDs in the graph.
+        If d is non-negative, it returns edges within a distance d from the point (x, y).
+        May return edges that are farther than d but will always return edges that are within d.
+
+        "Within" means that atleast one of the edge's nodes is within distance d from the point (x, y).
 
         Returns:
             Iterator[int]: An iterator that yields edge IDs.
@@ -190,6 +227,22 @@ class IGraph(ABC):
 
         Raises:
             KeyError: If the edge with the specified ID does not exist.
+        """
+        pass
+
+    @abstractmethod
+    def get_neighbors(self, node_id: int) -> Iterator[int]:
+        """
+        Get the neighbors of a specific node.
+
+        Args:
+            node_id (int): The unique identifier of the node whose neighbors are to be retrieved.
+
+        Returns:
+            Iterator[int]: An iterator that yields the IDs of neighboring nodes.
+
+        Raises:
+            KeyError: If the node with the specified ID does not exist.
         """
         pass
 

--- a/gamms/typing/graph_engine.py
+++ b/gamms/typing/graph_engine.py
@@ -85,6 +85,7 @@ class IGraph(ABC):
         Raises:
             ValueError: If the edge_data is missing required fields, contains invalid data, or references non-existent nodes.
             KeyError: If an edge with the same ID already exists in the graph.
+            KeyError: If source or target nodes do not exist in the graph.
         """
         pass
 
@@ -174,14 +175,10 @@ class IGraph(ABC):
     @abstractmethod
     def remove_node(self, node_id: int) -> None:
         """
-        Remove a node from the graph.
+        Remove a node from the graph. Removing a node will also remove all edges connected to it.
 
         Args:
             node_id (int): The unique identifier of the node to be removed.
-
-        Raises:
-            KeyError: If the node with the specified ID does not exist.
-            ValueError: If removing the node would leave edges without valid source or target nodes.
         """
         pass
 
@@ -192,9 +189,6 @@ class IGraph(ABC):
 
         Args:
             edge_id (int): The unique identifier of the edge to be removed.
-
-        Raises:
-            KeyError: If the edge with the specified ID does not exist.
         """
         pass
 

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -1,0 +1,223 @@
+import unittest
+import gamms
+from shapely.geometry import LineString
+import networkx as nx
+
+class GraphTest(unittest.TestCase):
+    def test_node_add_get(self):
+        self.ctx.graph.graph.add_node({'id': 1, 'x': 0, 'y': 0})
+        node = self.ctx.graph.graph.get_node(1)
+        self.assertIsNotNone(node)
+        self.assertEqual(node.id, 1)
+        self.assertEqual(node.x, 0)
+        self.assertEqual(node.y, 0)
+
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.add_node({'id': 1, 'x': 0, 'y': 0})
+
+        with self.assertRaises(ValueError):
+            self.ctx.graph.graph.add_node({'id': 0,})
+        
+        with self.assertRaises(ValueError):
+            self.ctx.graph.graph.add_node({'x': 0, 'y': 0})
+        
+        with self.assertRaises(ValueError):
+            self.ctx.graph.graph.add_node({'id': 0, 'x': 0})
+        with self.assertRaises(ValueError):
+            self.ctx.graph.graph.add_node({'id': 0, 'y': 0})
+        
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.get_node(2)
+    
+    def test_edge_add_get(self):
+        self.ctx.graph.graph.add_node({'id': 1, 'x': 0, 'y': 0})
+        self.ctx.graph.graph.add_node({'id': 2, 'x': 1, 'y': 1})
+        self.ctx.graph.graph.add_edge({'id': 1, 'source': 1, 'target': 2, 'length': 1})
+
+        # Check if the edge was added correctly
+        edge = self.ctx.graph.graph.get_edge(1)
+        self.assertIsNotNone(edge)
+        self.assertEqual(edge.id, 1)
+        self.assertEqual(edge.source, 1)
+        self.assertEqual(edge.target, 2)
+        self.assertEqual(edge.length, 1)
+
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.add_edge({'id': 1, 'source': 1, 'target': 2, 'length': 1})
+
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.add_edge({'id': 3, 'source': 1, 'target': 4, 'length': 1, 'linestring': LineString([(0, 0), (1, 1)])})
+
+        with self.assertRaises(ValueError):
+            self.ctx.graph.graph.add_edge({'id': 1, 'source': 1, 'target': 2})
+
+
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.get_edge(2)
+    
+    def test_get_nodes(self):
+        self.ctx.graph.graph.add_node({'id': 1, 'x': 0, 'y': 0})
+        self.ctx.graph.graph.add_node({'id': 2, 'x': 1, 'y': 1})
+        self.ctx.graph.graph.add_node({'id': 3, 'x': 2, 'y': 2})
+
+        nodes = list(self.ctx.graph.graph.get_nodes())
+        self.assertEqual(len(nodes), 3)
+        self.assertIn(1, nodes)
+        self.assertIn(2, nodes)
+        self.assertIn(3, nodes)
+
+        self.ctx.graph.graph.add_node({'id': 4, 'x': 100, 'y': 3})
+        self.ctx.graph.graph.add_node({'id': 5, 'x': 101, 'y': 4})
+
+        nodes = list(self.ctx.graph.graph.get_nodes(d=10, x=0, y=0))
+        self.assertGreaterEqual(len(nodes), 3)
+        self.assertIn(1, nodes)
+        self.assertIn(2, nodes)
+        self.assertIn(3, nodes)
+
+        nodes = list(self.ctx.graph.graph.get_nodes(d=-1.0, x=0, y=0))
+        self.assertEqual(len(nodes), 5)
+        self.assertIn(1, nodes)
+        self.assertIn(2, nodes)
+        self.assertIn(3, nodes)
+        self.assertIn(4, nodes)
+        self.assertIn(5, nodes)
+    
+    def test_get_edges(self):
+        self.ctx.graph.graph.add_node({'id': 1, 'x': 0, 'y': 0})
+        self.ctx.graph.graph.add_node({'id': 2, 'x': 1, 'y': 1})
+        self.ctx.graph.graph.add_node({'id': 3, 'x': 2, 'y': 2})
+
+        self.ctx.graph.graph.add_edge({'id': 1, 'source': 1, 'target': 2, 'length': 1})
+        self.ctx.graph.graph.add_edge({'id': 2, 'source': 2, 'target': 3, 'length': 1})
+
+        edges = list(self.ctx.graph.graph.get_edges())
+        self.assertEqual(len(edges), 2)
+        self.assertIn(1, edges)
+        self.assertIn(2, edges)
+
+        self.ctx.graph.graph.add_node({'id': 4, 'x': 100, 'y': 3})
+        self.ctx.graph.graph.add_node({'id': 5, 'x': 101, 'y': 4})
+
+        self.ctx.graph.graph.add_edge({'id': 3, 'source': 4, 'target': 5, 'length': 2})
+
+        edges = list(self.ctx.graph.graph.get_edges(d=10, x=0, y=0))
+        self.assertGreaterEqual(len(edges), 2)
+        self.assertIn(1, edges)
+        self.assertIn(2, edges)
+
+        edges = list(self.ctx.graph.graph.get_edges(d=-1.0, x=0, y=0))
+        self.assertEqual(len(edges), 3)
+        self.assertIn(1, edges)
+        self.assertIn(2, edges)
+        self.assertIn(3, edges)
+    
+    def test_remove_node_edge(self):
+        self.ctx.graph.graph.add_node({'id': 1, 'x': 0, 'y': 0})
+        self.ctx.graph.graph.add_node({'id': 2, 'x': 1, 'y': 1})
+        self.ctx.graph.graph.add_edge({'id': 1, 'source': 1, 'target': 2, 'length': 1})
+
+        # Remove edge
+        self.ctx.graph.graph.remove_edge(1)
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.get_edge(1)
+
+        # Remove node
+        self.ctx.graph.graph.remove_node(1)
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.get_node(1)
+        
+        self.ctx.graph.graph.remove_node(2)
+        
+        self.ctx.graph.graph.add_node({'id': 1, 'x': 0, 'y': 0})
+        self.ctx.graph.graph.add_node({'id': 2, 'x': 1, 'y': 1})
+        self.ctx.graph.graph.add_edge({'id': 1, 'source': 1, 'target': 2, 'length': 1})
+
+        # Remove node
+        self.ctx.graph.graph.remove_node(2)
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.get_node(2)
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.get_edge(1)
+        
+        # Check if the other node is still there
+        node = self.ctx.graph.graph.get_node(1)
+        self.assertIsNotNone(node)
+    
+    def test_update_node_edge(self):
+        self.ctx.graph.graph.add_node({'id': 1, 'x': 0, 'y': 0})
+        self.ctx.graph.graph.add_node({'id': 2, 'x': 1, 'y': 1})
+        self.ctx.graph.graph.add_edge({'id': 1, 'source': 1, 'target': 2, 'length': 1})
+
+        # Update node
+        self.ctx.graph.graph.update_node({'id': 1, 'x': 10, 'y': 20})
+        node = self.ctx.graph.graph.get_node(1)
+        self.assertEqual(node.x, 10)
+        self.assertEqual(node.y, 20)
+
+        # Update edge
+        self.ctx.graph.graph.update_edge({'id': 1, 'source': 1, 'target': 2, 'length': 2})
+        edge = self.ctx.graph.graph.get_edge(1)
+        self.assertEqual(edge.length, 2)
+        
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.update_node({'id': 3, 'x': 10, 'y': 20})
+        
+        with self.assertRaises(KeyError):
+            self.ctx.graph.graph.update_edge({'id': 3, 'source': 1, 'target': 2, 'length': 2})
+        
+    def test_get_neighbors(self):
+        self.ctx.graph.graph.add_node({'id': 1, 'x': 0, 'y': 0})
+        self.ctx.graph.graph.add_node({'id': 2, 'x': 1, 'y': 1})
+        self.ctx.graph.graph.add_node({'id': 3, 'x': 2, 'y': 2})
+        self.ctx.graph.graph.add_edge({'id': 1, 'source': 2, 'target': 1, 'length': 1})
+        self.ctx.graph.graph.add_edge({'id': 2, 'source': 2, 'target': 3, 'length': 1})
+
+        neighbors = list(self.ctx.graph.graph.get_neighbors(2))
+        self.assertEqual(len(neighbors), 2)
+        self.assertIn(1, neighbors)
+        self.assertIn(3, neighbors)
+    
+    def test_attach_network(self):
+        with self.assertRaises(ValueError):
+            self.ctx.graph.attach_networkx_graph(None)
+
+        G = nx.DiGraph()
+        G.add_node(1, x=0, y=0)
+        G.add_node(2, x=1, y=1)
+        G.add_edge(1, 2, id=1, length=1)
+        self.ctx.graph.attach_networkx_graph(G)
+
+        self.ctx.graph.graph.get_node(1)
+        self.ctx.graph.graph.get_node(2)
+        self.ctx.graph.graph.get_edge(1)
+
+    def tearDown(self) -> None:
+        self.ctx.terminate()
+
+
+class MemoryGraphTest(GraphTest):
+    def setUp(self):
+        self.ctx = gamms.create_context(vis_engine=gamms.visual.Engine.NO_VIS, graph_engine=gamms.graph.Engine.MEMORY, logger_config={'level': 'ERROR'})
+
+class SQLiteGraphTest(GraphTest):
+    def setUp(self) -> None:
+        self.ctx = gamms.create_context(vis_engine=gamms.visual.Engine.NO_VIS, graph_engine=gamms.graph.Engine.SQLITE, logger_config={'level': 'ERROR'})
+
+
+def suite(cls):
+    suite = unittest.TestSuite()
+    suite.addTest(cls('test_node_add_get'))
+    suite.addTest(cls('test_edge_add_get'))
+    suite.addTest(cls('test_get_nodes'))
+    suite.addTest(cls('test_get_edges'))
+    suite.addTest(cls('test_remove_node_edge'))
+    suite.addTest(cls('test_update_node_edge'))
+    suite.addTest(cls('test_get_neighbors'))
+    suite.addTest(cls('test_attach_network'))
+    return suite
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite(MemoryGraphTest))
+    runner.run(suite(SQLiteGraphTest))


### PR DESCRIPTION
Instead of creating a memory engine #8, an intermediate version 0.2.5 will be released without a lower level implementation. Instead, only the graph will use the sqlite backend.

This PR does the following:
- Create an sqlite implementation for `IGraph`
- Extend the `IGraph` interface and update some corner cases
- Add a test suite for `IGraph` (to be maintained with each extension)
- Correction in `Graph` implementation which were missed during initial development
- Modified sensors to use the graph api only rather than caching