### PR TITLE
Realign stores, graphs, sensors with new IStore abstraction.

### DIFF
--- a/gamms/GraphEngine/graph_engine.py
+++ b/gamms/GraphEngine/graph_engine.py
@@ -1,26 +1,53 @@
-import networkx as nx
-from typing import Dict, Any, Iterator, cast, Union, Set, overload, Optional
-from enum import Enum
-from gamms.typing import Node, OSMEdge, IGraph, IGraphEngine, IContext
-from gamms.typing.graph_engine import Engine
-from gamms.typing.memory_engine import IStore, StoreType
+import os
 import pickle
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Union, cast, overload
+
+import cbor2
+import networkx as nx
 from shapely.geometry import LineString
 
-from dataclasses import dataclass
-
-import sqlite3
-
-import tempfile
-import cbor2
+from gamms.typing import IContext, IGraph, IGraphEngine, Node, OSMEdge
+from gamms.typing.graph_engine import Engine
+from gamms.typing.memory_engine import StoreType
+from gamms.MemoryEngine.store import MemoryStore, PathLike, SqliteStore
 
 
-POLYGON_STORE_NAME = "graph_polygons"
-POLYGON_MAP_NAME = "polygons"
+GRAPH_STORE_NAME = "graph"
+NODES_MAP = "nodes"
+EDGES_MAP = "edges"
+POLYGONS_MAP = "polygons"
 DEFAULT_BUILDING_HEIGHT = 6.0  # ~2-storey building (metres)
 
 
-def _normalize_polygon_coords(coords: Any) -> list:
+_mem_Node = dataclass()(Node)
+
+
+class _OSMEdge(OSMEdge):
+    """Edge wrapper with a lazy ``linestring`` property.
+
+    Geometry is stored as a tuple-of-(x, y) coordinates; we only build the
+    Shapely ``LineString`` on access.
+    """
+
+    __slots__ = ("id", "source", "target", "length", "_geom")
+
+    def __init__(self, edge_id: int, source: int, target: int, length: float, geom: Tuple[Tuple[float, float], ...]):
+        self.id = edge_id
+        self.source = source
+        self.target = target
+        self.length = length
+        self._geom = geom
+
+    @property
+    def linestring(self) -> LineString:
+        return LineString(self._geom)
+
+
+def _normalize_polygon_coords(coords: Any) -> Tuple[Tuple[float, float], ...]:
     pts = [tuple(c) for c in coords]
     if len(pts) < 3:
         raise ValueError("Polygon must have at least 3 vertices.")
@@ -28,512 +55,249 @@ def _normalize_polygon_coords(coords: Any) -> list:
         pts = pts[:-1]
     if len(pts) < 3:
         raise ValueError("Polygon must have at least 3 distinct vertices.")
-    return pts
+    return tuple((float(x), float(y)) for x, y in pts)
 
 
-_mem_Node = dataclass()(Node)
-_mem_OSMEdge = dataclass()(OSMEdge)
+def _polygon_bbox(coords: Tuple[Tuple[float, float], ...]) -> Tuple[float, float, float, float]:
+    xs = [c[0] for c in coords]
+    ys = [c[1] for c in coords]
+    return (min(xs), min(ys), max(xs), max(ys))
 
-class Graph(IGraph):
-    def __init__(self):
-        self.nodes: Dict[int, Node] = {}
-        self.edges: Dict[int, OSMEdge] = {}
-        self._adjacency: Dict[int, Set[int]] = {}
-    
-    def get_edge(self, edge_id: int) -> OSMEdge:
-        return self.edges[edge_id]
 
-    @overload
-    def get_edges(self) -> Iterator[int]: ...
-    @overload
-    def get_edges(self, d: float, x: float, y: float) -> Iterator[int]: ...
-    def get_edges(self, d: float = -1.0, x: float = 0, y: float = 0) -> Iterator[int]:
-        return iter(self.edges.keys())
-    
-    def get_node(self, node_id: int) -> Node:
-        return self.nodes[node_id]
-    
-    @overload
-    def get_nodes(self) -> Iterator[int]: ...
-    @overload
-    def get_nodes(self, d: float, x: float, y: float) -> Iterator[int]: ...
-    def get_nodes(self, d: float = -1.0, x: float = 0, y: float = 0) -> Iterator[int]:
-        return iter(self.nodes.keys())
-    
-    def add_node(self, node_data: Dict[str, Any]) -> None:
+class _GraphBase(IGraph):
+    """Shared validation/normalization for both graph backends."""
+
+    @staticmethod
+    def _validate_node_data(node_data: Dict[str, Any]) -> Tuple[int, float, float]:
         if 'id' not in node_data or 'x' not in node_data or 'y' not in node_data:
             raise ValueError("Node data must include 'id', 'x', and 'y'.")
+        return int(node_data['id']), float(node_data['x']), float(node_data['y'])
 
-        if node_data['id'] in self.nodes:
-            raise KeyError(f"Node {node_data['id']} already exists.")
-                
-        node = _mem_Node(id=node_data['id'], x=node_data['x'], y=node_data['y'])
-        self.nodes[node_data['id']] = node
-        self._adjacency[node_data['id']] = set()
-    
-    def add_edge(self, edge_data: Dict[str, Any]) -> None:
-        if 'id' not in edge_data or 'source' not in edge_data or 'target' not in edge_data or 'length' not in edge_data:
-            raise ValueError("Edge data must include 'id', 'source', 'target', and 'length'.")
-        
-        if edge_data['id'] in self.edges:
-            raise KeyError(f"Edge {edge_data['id']} already exists.")
-        
+    @staticmethod
+    def _normalize_linestring(
+        edge_data: Dict[str, Any],
+        get_node: Callable[[int], Node],
+    ) -> Tuple[Tuple[float, float], ...]:
         linestring = edge_data.get('linestring', None)
         if linestring is None:
-            # Create a LineString from the source and target node coordinates
-            source_node = self.get_node(edge_data['source'])
-            target_node = self.get_node(edge_data['target'])
-            linestring = LineString([(source_node.x, source_node.y), (target_node.x, target_node.y)])
-        elif not isinstance(linestring, LineString):
-            try:
-                linestring = LineString(linestring)
-            except Exception as e:
-                raise ValueError(f"Invalid linestring data: {linestring}") from e
-        if linestring.is_empty:
-            raise ValueError(f"Invalid linestring: {linestring}")
-        
-        if edge_data['source'] not in self.nodes or edge_data['target'] not in self.nodes:
-            raise KeyError(f"Source or target node does not exist in the graph: {edge_data['source']}, {edge_data['target']}")
-        
-        edge = _mem_OSMEdge(
-            id = edge_data['id'],
-            source=edge_data['source'],
-            target=edge_data['target'],
-            length=edge_data['length'],
-            linestring=linestring
-        )
+            source_node = get_node(edge_data['source'])
+            target_node = get_node(edge_data['target'])
+            return ((source_node.x, source_node.y), (target_node.x, target_node.y))
+        if isinstance(linestring, LineString):
+            if linestring.is_empty:
+                raise ValueError(f"Invalid linestring: {linestring}")
+            return tuple((float(x), float(y)) for x, y in linestring.coords)
+        try:
+            shaped = LineString(linestring)
+            if shaped.is_empty:
+                raise ValueError(f"Invalid linestring: {linestring}")
+            return tuple((float(x), float(y)) for x, y in shaped.coords)
+        except Exception as exc:
+            raise ValueError(f"Invalid linestring data: {linestring}") from exc
 
-        self.edges[edge_data['id']] = edge
-        self._adjacency[edge_data['source']].add(edge_data['target'])
+    @staticmethod
+    def _validate_edge_data(edge_data: Dict[str, Any]) -> None:
+        for field in ('id', 'source', 'target', 'length'):
+            if field not in edge_data:
+                raise ValueError("Edge data must include 'id', 'source', 'target', and 'length'.")
+
+    @staticmethod
+    def _edge_bbox_from_geom(geom: Tuple[Tuple[float, float], ...]) -> Tuple[float, float, float, float]:
+        xs = [c[0] for c in geom]
+        ys = [c[1] for c in geom]
+        return (min(xs), min(ys), max(xs), max(ys))
+
+    def attach_networkx_graph(self, G: nx.Graph) -> None:
+        for node, data in G.nodes(data=True):  # type: ignore
+            node = cast(int, node)
+            data = cast(Dict[str, Any], data)
+            self.add_node({
+                'id': node,
+                'x': data.get('x', 0.0),
+                'y': data.get('y', 0.0),
+            })
+        for u, v, data in G.edges(data=True):  # type: ignore
+            u = cast(int, u)
+            v = cast(int, v)
+            data = cast(Dict[str, Any], data)
+            self.add_edge({
+                'id': data.get('id', -1),
+                'source': u,
+                'target': v,
+                'length': data.get('length', 0.0),
+                'linestring': data.get('linestring', None),
+            })
+
+
+class Graph(_GraphBase):
+    """In-memory graph backed by a :class:`MemoryStore`."""
+
+    def __init__(self, store: MemoryStore):
+        self._store = store
+        store.create_map(NODES_MAP, {'id': int, 'x': float, 'y': float}, 'id')
+        store.create_map(
+            EDGES_MAP,
+            {
+                'id': int, 'source': int, 'target': int, 'length': float,
+                'geom': tuple,
+                'min_x': float, 'min_y': float, 'max_x': float, 'max_y': float,
+            },
+            'id',
+        )
+        store.create_map(
+            POLYGONS_MAP,
+            {
+                'id': int, 'coords': tuple, 'height': float, 'base': float,
+                'category': str, 'attributes': dict,
+                'min_x': float, 'min_y': float, 'max_x': float, 'max_y': float,
+            },
+            'id',
+        )
+        self._nodes_map: Dict[int, Dict[str, Any]] = store.get_map(NODES_MAP)
+        self._edges_map: Dict[int, Dict[str, Any]] = store.get_map(EDGES_MAP)
+        self._polygons_map: Dict[int, Dict[str, Any]] = store.get_map(POLYGONS_MAP)
+        self._adjacency: Dict[int, Set[int]] = {}
+
+    # ---- nodes -----------------------------------------------------------
+
+    def add_node(self, node_data: Dict[str, Any]) -> None:
+        node_id, x, y = self._validate_node_data(node_data)
+        if node_id in self._nodes_map:
+            raise KeyError(f"Node {node_id} already exists.")
+        self._store.insert_data(NODES_MAP, {'id': node_id, 'x': x, 'y': y})
+        self._adjacency.setdefault(node_id, set())
 
     def update_node(self, node_data: Dict[str, Any]) -> None:
-    
-        if node_data['id'] not in self.nodes:
-            raise KeyError(f"Node {node_data['id']} does not exist.")
-        
-        node = self.nodes[node_data['id']]
-        node.x = node_data.get('x', node.x)
-        node.y = node_data.get('y', node.y)
-    
-    def update_edge(self, edge_data: Dict[str, Any]) -> None:
-
-        if edge_data['id'] not in self.edges:
-            raise KeyError(f"Edge {edge_data['id']} does not exist. Use add_edge to create it.")
-        edge = self.edges[edge_data['id']]
-
-        self._adjacency[edge.source].discard(edge.target)
-
-        edge.source = edge_data.get('source', edge.source)
-        edge.target = edge_data.get('target', edge.target)
-        edge.length = edge_data.get('length', edge.length)
-        edge.linestring = edge_data.get('linestring', edge.linestring)
-
-        self._adjacency[edge.source].add(edge.target)
+        if 'id' not in node_data:
+            raise ValueError("Node data must include 'id'.")
+        node_id = int(node_data['id'])
+        if node_id not in self._nodes_map:
+            raise KeyError(f"Node {node_id} does not exist.")
+        update: Dict[str, Any] = {'id': node_id}
+        if 'x' in node_data:
+            update['x'] = float(node_data['x'])
+        if 'y' in node_data:
+            update['y'] = float(node_data['y'])
+        self._store.update_data(NODES_MAP, update)
 
     def remove_node(self, node_id: int) -> None:
-        if node_id not in self.nodes:
+        if node_id not in self._nodes_map:
             return
-        
-        edges_to_remove = [key for key, edge in self.edges.items() if edge.source == node_id or edge.target == node_id]
-        for key in edges_to_remove:
-            del self.edges[key]
-        del self.nodes[node_id]
-        del self._adjacency[node_id]
+        edges_to_remove = [
+            eid for eid, edge in self._edges_map.items()
+            if edge['source'] == node_id or edge['target'] == node_id
+        ]
+        for eid in edges_to_remove:
+            self._adjacency.get(self._edges_map[eid]['source'], set()).discard(
+                self._edges_map[eid]['target']
+            )
+            self._store.delete_data(EDGES_MAP, eid)
+        self._store.delete_data(NODES_MAP, node_id)
+        self._adjacency.pop(node_id, None)
         for neighbors in self._adjacency.values():
             neighbors.discard(node_id)
 
-    def remove_edge(self, edge_id: int) -> None:
-        if edge_id not in self.edges:
-            return        
-        edge = self.edges[edge_id]
-        self._adjacency[edge.source].discard(edge.target)
-        del self.edges[edge_id]
-    
-    def attach_networkx_graph(self, G: nx.Graph) -> None:
-        for node, data in G.nodes(data=True): # type: ignore
-            node = cast(int, node)
-            data = cast(Dict[str, Any], data)
-            node_data: Dict[str, Union[int, float]] = {
-                'id': node,
-                'x': data.get('x', 0.0),
-                'y': data.get('y', 0.0)
-            }
-            self.add_node(node_data)
-            
-        for u, v, data in G.edges(data=True): # type: ignore
-            u = cast(int, u)
-            v = cast(int, v)
-            data = cast(Dict[str, Any], data)
-            linestring = data.get('linestring', None)
-            if linestring is None:
-                # Create a LineString from the source and target node coordinates
-                source_node = self.get_node(u)
-                target_node = self.get_node(v)
-                linestring = LineString([(source_node.x, source_node.y), (target_node.x, target_node.y)])
-            elif not isinstance(linestring, LineString):
-                try:
-                    linestring = LineString(linestring)
-                except Exception as e:
-                    raise ValueError(f"Invalid linestring data: {linestring}") from e
-            if linestring.is_empty:
-                raise ValueError(f"Invalid linestring: {linestring}")
-            edge_data: Dict[str, Any] = {
-                'id': data.get('id', -1),
-                'source': u,
-                'target': v,
-                'length': data.get('length', 0.0),
-                'linestring': linestring
-            }
-            self.add_edge(edge_data)
-    
-
-    def get_neighbors(self, node_id: int) -> Iterator[int]:
-        if node_id not in self.nodes:
-            raise KeyError(f"Node {node_id} does not exist.")
-
-        for neighbor in self._adjacency[node_id]:
-            yield neighbor
-                
-    def save(self, path: str) -> None:
-        """
-        Saves the graph to a file.
-        """
-        pickle.dump({"nodes": self.nodes, "edges": self.edges}, open(path, 'wb'))
-        print(f"Graph saved to {path}")
-
-    def load(self, path: str) -> None:
-        """
-        Loads the graph from a file.
-        """
-        data = pickle.load(open(path, 'rb'))
-        self.nodes = data['nodes']
-        self.edges = data['edges']
-        self._adjacency = {node_id: set() for node_id in self.nodes.keys()}
-        for edge in self.edges.values():
-            self._adjacency[edge.source].add(edge.target)
-
-_sql_Node = _mem_Node
-
-class _sql_OSMEdge(OSMEdge):
-    __slots__ = ('id', 'source', 'target', 'length', '_geom')
-
-    def __init__(self, row: sqlite3.Row):
-        self.id: int = row[0]
-        self.source: int = row[1]
-        self.target: int = row[2]
-        self.length: float = row[3]
-        self._geom = row[4]
-    
-    @property
-    def linestring(self) -> LineString:
-        return LineString(cbor2.loads(self._geom))
-
-class SqliteGraph(IGraph):
-    def __init__(self):
-        # Create a random name for the SQLite database
-        self._dbdir = tempfile.TemporaryDirectory(dir=".")
-        self._conn = sqlite3.connect(f"{self._dbdir.name}/graph.db", isolation_level=None)
-        self._cursor = self._conn.cursor()
-        # Enable foreign key constraints and set journal mode to WAL for better concurrency
-        # Also set temp_store to MEMORY for faster temporary storage
-        self._cursor.executescript(
-            "PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL;PRAGMA temp_store = MEMORY;"
-        )
-        self._cursor.execute(
-            "CREATE TABLE IF NOT EXISTS nodes (id INTEGER PRIMARY KEY, x REAL, y REAL)"
-        )
-        # Create index on node x,y for faster lookups
-        self._cursor.execute("CREATE INDEX IF NOT EXISTS idx_nodes_xy ON nodes (x, y)")
-        self._cursor.execute(
-            "CREATE TABLE IF NOT EXISTS edges (id INTEGER PRIMARY KEY, source INTEGER, target INTEGER, length REAL, geom BLOB, FOREIGN KEY(source) REFERENCES nodes(id), FOREIGN KEY(target) REFERENCES nodes(id))"
-        )
-        # Create index on edge source,target for faster lookups
-        self._cursor.execute("CREATE INDEX IF NOT EXISTS idx_edges_source_target ON edges (source, target)")
-        self._conn.commit()
-        self._call_commit = False
-    
-    def __del__(self):
-        """
-        Destructor to close the database connection.
-        """
-        self._conn.close()
-        if self._dbdir:
-            self._dbdir.cleanup()
-    
-    def add_node(self, node_data: Dict[str, Any]) -> None:
-        """
-        Adds a node to the graph.
-        """
-        if 'id' not in node_data or 'x' not in node_data or 'y' not in node_data:
-            raise ValueError("Node data must include 'id', 'x', and 'y'.")
-        
-        try:
-            self._cursor.execute("INSERT INTO nodes (id, x, y) VALUES (?, ?, ?)", 
-                           (node_data['id'], node_data['x'], node_data['y']))
-        except sqlite3.IntegrityError as e:
-            if "UNIQUE constraint failed" in str(e):
-                raise KeyError(f"Node {node_data['id']} already exists.") from e
-        
-        self._call_commit = True
-    
-    def add_edge(self, edge_data: Dict[str, Any]) -> None:
-        """
-        Adds an edge to the graph.
-        """
-        if 'id' not in edge_data or 'source' not in edge_data or 'target' not in edge_data or 'length' not in edge_data:
-            raise ValueError("Edge data must include 'id', 'source', 'target', and 'length'.")
-        
-        linestring = edge_data.get('linestring', None)
-        if linestring is None:
-            # Create a LineString from the source and target node coordinates
-            com_val = self._call_commit
-            self._call_commit = False
-            source_node = self.get_node(edge_data['source'])
-            target_node = self.get_node(edge_data['target'])
-            self._call_commit = com_val
-            linestring = ((source_node.x, source_node.y), (target_node.x, target_node.y))
-        elif not isinstance(linestring, LineString):
-            try:
-                linestring = LineString(linestring)
-                linestring = tuple(linestring.coords)
-            except Exception as e:
-                raise ValueError(f"Invalid linestring data: {linestring}") from e
-        else:
-            linestring = tuple(linestring.coords)
-
-        try:
-            self._cursor.execute("INSERT INTO edges (id, source, target, length, geom) VALUES (?, ?, ?, ?, ?)",
-                           (edge_data['id'], edge_data['source'], edge_data['target'], edge_data['length'], cbor2.dumps(linestring)))
-        except sqlite3.IntegrityError as e:
-            if "UNIQUE constraint failed" in str(e):
-                raise KeyError(f"Edge {edge_data['id']} already exists.") from e
-            elif "FOREIGN KEY constraint failed" in str(e):
-                raise KeyError(f"Source or target node does not exist in the graph: {edge_data['source']}, {edge_data['target']}") from e
-
-        self._call_commit = True
-    
     def get_node(self, node_id: int) -> Node:
-        """
-        Retrieves a node by its ID.
-        """
-        if self._call_commit:
-            self._conn.commit()
-            self._call_commit = False
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT id, x, y FROM nodes WHERE id = ?", (node_id,))
-        row = cursor.fetchone()
-        if row is None:
+        if node_id not in self._nodes_map:
             raise KeyError(f"Node {node_id} does not exist.")
-        
-        return _sql_Node(id=row[0], x=row[1], y=row[2])
-    
-    @overload
-    def get_edges(self) -> Iterator[int]: ...
-    @overload
-    def get_edges(self, d: float, x: float, y: float) -> Iterator[int]: ...
-    def get_edges(self, d: float = -1.0, x: float = 0, y: float = 0) -> Iterator[int]:
-        """
-        Returns an iterator over all edge IDs in the graph.
-        """
-        if self._call_commit:
-            self._conn.commit()
-            self._call_commit = False
-        cursor = self._conn.cursor()
-        if d >= 0:
-            x_min, x_max = x - d, x + d
-            y_min, y_max = y - d, y + d
-            cursor.execute("SELECT edges.id FROM edges JOIN nodes AS u ON edges.source = u.id JOIN nodes AS v ON edges.target = v.id WHERE (u.x BETWEEN ? AND ? AND u.y BETWEEN ? AND ?) OR (v.x BETWEEN ? AND ? AND v.y BETWEEN ? AND ?)",
-                           (x_min, x_max, y_min, y_max, x_min, x_max, y_min, y_max))
-        else:
-            cursor.execute("SELECT id FROM edges")
-        while True:
-            row = cursor.fetchone()
-            if row is None:
-                break
-            yield row[0]
-    
-    def get_edge(self, edge_id: int) -> OSMEdge:
-        """
-        Retrieves an edge by its ID.
-        """
-        if self._call_commit:
-            self._conn.commit()
-            self._call_commit = False
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT id, source, target, length, geom FROM edges WHERE id = ?", (edge_id,))
-        row = cursor.fetchone()
-        if row is None:
-            raise KeyError(f"Edge {edge_id} does not exist.")
-        
-        return _sql_OSMEdge(row)
-    
+        row = self._nodes_map[node_id]
+        return _mem_Node(id=row['id'], x=row['x'], y=row['y'])
+
     @overload
     def get_nodes(self) -> Iterator[int]: ...
     @overload
     def get_nodes(self, d: float, x: float, y: float) -> Iterator[int]: ...
-    def get_nodes(self, d: float = -1.0, x: float = 0, y: float = 0) -> Iterator[int]:
-        """
-        Returns an iterator over all node IDs in the graph.
-        """
-        if self._call_commit:
-            self._conn.commit()
-            self._call_commit = False
-        cursor = self._conn.cursor()
-        if d >= 0:
-            cursor.execute("SELECT id FROM nodes WHERE x BETWEEN ? AND ? AND y BETWEEN ? AND ?", (x - d, x + d, y - d, y + d))
-        else:
-            cursor.execute("SELECT id FROM nodes")
-        while True:
-            row = cursor.fetchone()
-            if row is None:
-                break
-            yield row[0]
-    
-    def update_node(self, node_data: Dict[str, Any]) -> None:
-        """
-        Updates a node in the graph.
-        """
-        if 'id' not in node_data or 'x' not in node_data or 'y' not in node_data:
-            raise ValueError("Node data must include 'id', 'x', and 'y'.")
-        
-        _ = self.get_node(node_data['id'])
-        
-        self._cursor.execute("UPDATE nodes SET x = ?, y = ? WHERE id = ?", 
-                       (node_data['x'], node_data['y'], node_data['id']))
-        
-        self._call_commit = True
-    
-    def update_edge(self, edge_data: Dict[str, Any]) -> None:
-        """
-        Updates an edge in the graph.
-        """
-        if 'id' not in edge_data or 'source' not in edge_data or 'target' not in edge_data or 'length' not in edge_data:
-            raise ValueError("Edge data must include 'id', 'source', 'target', and 'length'.")
-        
-        _ = self.get_edge(edge_data['id'])
-        
-        linestring = edge_data.get('linestring', None)
-        if linestring is None:
-            # Create a LineString from the source and target node coordinates
-            source_node = self.get_node(edge_data['source'])
-            target_node = self.get_node(edge_data['target'])
-            linestring = ((source_node.x, source_node.y), (target_node.x, target_node.y))
-        elif not isinstance(linestring, LineString):
-            try:
-                linestring = LineString(linestring)
-                linestring = tuple(linestring.coords)
-            except Exception as e:
-                raise ValueError(f"Invalid linestring data: {linestring}") from e
-        else:
-            linestring = tuple(linestring.coords)
-        
-        self._cursor.execute("UPDATE edges SET source = ?, target = ?, length = ?, geom = ? WHERE id = ?",
-                       (edge_data['source'], edge_data['target'], edge_data['length'], cbor2.dumps(linestring), edge_data['id']))
-        
-        self._call_commit = True
-    
-    def remove_node(self, node_id: int) -> None:
-        """
-        Removes a node from the graph.
-        """
-        # Remove edges associated with this node
-        self._cursor.execute("DELETE FROM edges WHERE source = ? OR target = ?", (node_id, node_id))
-        self._cursor.execute("DELETE FROM nodes WHERE id = ?", (node_id,))        
-        self._call_commit = True
-    
-    def remove_edge(self, edge_id: int) -> None:
-        """
-        Removes an edge from the graph.
-        """
-        self._cursor.execute("DELETE FROM edges WHERE id = ?", (edge_id,))
-        
-        self._call_commit = True
-    
-    def attach_networkx_graph(self, G: nx.Graph) -> None:
-        """
-        Attaches a NetworkX graph to the SqliteGraph object.
-        """
-        for node, data in G.nodes(data=True): # type: ignore
-            node = cast(int, node)
-            data = cast(Dict[str, Any], data)
-            node_data: Dict[str, Union[int, float]] = {
-                'id': node,
-                'x': data.get('x', 0.0),
-                'y': data.get('y', 0.0)
-            }
-            self.add_node(node_data)
-        
-        self._conn.commit()  # Commit after adding all nodes to ensure they are available for edge insertion
-        self._call_commit = False  # Reset call_commit flag after manual commit
-        
-        for u, v, data in G.edges(data=True): # type: ignore
-            u = cast(int, u)
-            v = cast(int, v)
-            data = cast(Dict[str, Any], data)
-            linestring = data.get('linestring', None)
-            edge_data: Dict[str, Any] = {
-                'id': data.get('id', -1),
-                'source': u,
-                'target': v,
-                'length': data.get('length', 0.0),
-                'linestring': linestring
-            }
-            self.add_edge(edge_data)
-        
-        self._conn.commit()  # Commit after adding all edges
-        self._call_commit = False  # Reset call_commit flag after manual commit
-    
-    def get_neighbors(self, node_id: int) -> Iterator[int]:
-        """
-        Returns an iterator over the neighbors of a given node.
-        """
-        _ = self.get_node(node_id)
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT target FROM edges WHERE source = ?", (node_id,))
-        while True:
-            row = cursor.fetchone()
-            if row is None:
-                break
-            yield row[0]
+    def get_nodes(self, d: float = -1.0, x: float = 0.0, y: float = 0.0) -> Iterator[int]:
+        if d < 0:
+            return iter(list(self._nodes_map.keys()))
+        x_min, x_max = x - d, x + d
+        y_min, y_max = y - d, y + d
+        return iter([
+            nid for nid, row in self._nodes_map.items()
+            if x_min <= row['x'] <= x_max and y_min <= row['y'] <= y_max
+        ])
 
-class GraphEngine(IGraphEngine):
-    def __init__(self, ctx: IContext, engine: Enum = Engine.SQLITE):
-        if engine == Engine.MEMORY:
-            self._graph = Graph()
-        elif engine == Engine.SQLITE:
-            self._graph = SqliteGraph()
-        else:
-            raise ValueError(f"Unsupported engine type: {engine}")
-        self.ctx = ctx
-        self._polygon_store: Optional[IStore] = None
+    # ---- edges -----------------------------------------------------------
 
-    @property
-    def graph(self) -> IGraph:
-        return self._graph
-
-    def _get_polygon_store(self) -> IStore:
-        """Lazily create the polygon store on the memory engine."""
-        if self._polygon_store is not None:
-            return self._polygon_store
-        ictx = getattr(self.ctx, "ictx", None)
-        if ictx is None or ictx.memory is None:
-            raise RuntimeError(
-                "Polygon store requires a memory engine. Initialise the context "
-                "via gamms.create_context() to enable it."
+    def add_edge(self, edge_data: Dict[str, Any]) -> None:
+        self._validate_edge_data(edge_data)
+        edge_id = int(edge_data['id'])
+        if edge_id in self._edges_map:
+            raise KeyError(f"Edge {edge_id} already exists.")
+        source = int(edge_data['source'])
+        target = int(edge_data['target'])
+        if source not in self._nodes_map or target not in self._nodes_map:
+            raise KeyError(
+                f"Source or target node does not exist in the graph: {source}, {target}"
             )
-        memory_engine = ictx.memory
-        if POLYGON_STORE_NAME in memory_engine.list_stores():
-            store = memory_engine.get_store(POLYGON_STORE_NAME)
-        else:
-            store = memory_engine.create_store(StoreType.MEMORY, POLYGON_STORE_NAME)
-        if not store.has_map(POLYGON_MAP_NAME):
-            store.create_map(POLYGON_MAP_NAME, value_type=dict)
-        self._polygon_store = store
-        return store
+        geom = self._normalize_linestring(edge_data, self.get_node)
+        bbox = self._edge_bbox_from_geom(geom)
+        self._store.insert_data(EDGES_MAP, {
+            'id': edge_id,
+            'source': source,
+            'target': target,
+            'length': float(edge_data['length']),
+            'geom': geom,
+            'min_x': bbox[0], 'min_y': bbox[1], 'max_x': bbox[2], 'max_y': bbox[3],
+        })
+        self._adjacency.setdefault(source, set()).add(target)
 
-    @property
-    def polygon_store(self) -> IStore:
-        return self._get_polygon_store()
+    def update_edge(self, edge_data: Dict[str, Any]) -> None:
+        self._validate_edge_data(edge_data)
+        edge_id = int(edge_data['id'])
+        if edge_id not in self._edges_map:
+            raise KeyError(f"Edge {edge_id} does not exist. Use add_edge to create it.")
+        existing = self._edges_map[edge_id]
+        self._adjacency.get(existing['source'], set()).discard(existing['target'])
+        source = int(edge_data['source'])
+        target = int(edge_data['target'])
+        geom = self._normalize_linestring(edge_data, self.get_node)
+        bbox = self._edge_bbox_from_geom(geom)
+        self._store.update_data(EDGES_MAP, {
+            'id': edge_id,
+            'source': source,
+            'target': target,
+            'length': float(edge_data['length']),
+            'geom': geom,
+            'min_x': bbox[0], 'min_y': bbox[1], 'max_x': bbox[2], 'max_y': bbox[3],
+        })
+        self._adjacency.setdefault(source, set()).add(target)
+
+    def remove_edge(self, edge_id: int) -> None:
+        if edge_id not in self._edges_map:
+            return
+        edge = self._edges_map[edge_id]
+        self._adjacency.get(edge['source'], set()).discard(edge['target'])
+        self._store.delete_data(EDGES_MAP, edge_id)
+
+    def get_edge(self, edge_id: int) -> OSMEdge:
+        if edge_id not in self._edges_map:
+            raise KeyError(f"Edge {edge_id} does not exist.")
+        row = self._edges_map[edge_id]
+        return _OSMEdge(row['id'], row['source'], row['target'], row['length'], row['geom'])
+
+    @overload
+    def get_edges(self) -> Iterator[int]: ...
+    @overload
+    def get_edges(self, d: float, x: float, y: float) -> Iterator[int]: ...
+    def get_edges(self, d: float = -1.0, x: float = 0.0, y: float = 0.0) -> Iterator[int]:
+        if d < 0:
+            return iter(list(self._edges_map.keys()))
+        x_min, x_max = x - d, x + d
+        y_min, y_max = y - d, y + d
+        return iter([
+            eid for eid, row in self._edges_map.items()
+            if not (row['max_x'] < x_min or row['min_x'] > x_max
+                    or row['max_y'] < y_min or row['min_y'] > y_max)
+        ])
+
+    def get_neighbors(self, node_id: int) -> Iterator[int]:
+        if node_id not in self._nodes_map:
+            raise KeyError(f"Node {node_id} does not exist.")
+        for nid in self._adjacency.get(node_id, ()):
+            yield nid
+
+    # ---- polygons --------------------------------------------------------
 
     def add_polygon(
         self,
@@ -544,52 +308,431 @@ class GraphEngine(IGraphEngine):
         category: str = "building",
         attributes: Optional[Dict[str, Any]] = None,
     ) -> None:
-        store = self._get_polygon_store()
-        coords_list = _normalize_polygon_coords(coords)
+        if polygon_id in self._polygons_map:
+            raise ValueError(f"Polygon {polygon_id} already exists.")
         if height <= 0:
             raise ValueError("Polygon height must be positive.")
-        record = {
-            "id": polygon_id,
-            "coords": coords_list,
-            "height": float(height),
-            "base": float(base),
-            "category": category,
-            "attributes": attributes or {},
-        }
-        store.insert_data(POLYGON_MAP_NAME, polygon_id, record)
+        normalized = _normalize_polygon_coords(coords)
+        bbox = _polygon_bbox(normalized)
+        self._store.insert_data(POLYGONS_MAP, {
+            'id': int(polygon_id),
+            'coords': normalized,
+            'height': float(height),
+            'base': float(base),
+            'category': str(category),
+            'attributes': dict(attributes or {}),
+            'min_x': bbox[0], 'min_y': bbox[1], 'max_x': bbox[2], 'max_y': bbox[3],
+        })
 
     def get_polygon(self, polygon_id: int) -> Dict[str, Any]:
-        store = self._get_polygon_store()
-        return store.get_data(POLYGON_MAP_NAME, polygon_id)
+        if polygon_id not in self._polygons_map:
+            raise KeyError(f"Polygon {polygon_id} does not exist.")
+        row = self._polygons_map[polygon_id]
+        return {
+            'id': row['id'],
+            'coords': list(row['coords']),
+            'height': row['height'],
+            'base': row['base'],
+            'category': row['category'],
+            'attributes': dict(row['attributes']),
+        }
 
-    def get_polygons(self) -> Iterator[int]:
-        store = self._get_polygon_store()
-        return store.keys(POLYGON_MAP_NAME)
+    @overload
+    def get_polygons(self) -> Iterator[int]: ...
+    @overload
+    def get_polygons(self, d: float, x: float, y: float) -> Iterator[int]: ...
+    def get_polygons(self, d: float = -1.0, x: float = 0.0, y: float = 0.0) -> Iterator[int]:
+        if d < 0:
+            return iter(list(self._polygons_map.keys()))
+        x_min, x_max = x - d, x + d
+        y_min, y_max = y - d, y + d
+        return iter([
+            pid for pid, row in self._polygons_map.items()
+            if not (row['max_x'] < x_min or row['min_x'] > x_max
+                    or row['max_y'] < y_min or row['min_y'] > y_max)
+        ])
 
     def remove_polygon(self, polygon_id: int) -> None:
-        store = self._get_polygon_store()
-        store.delete_data(POLYGON_MAP_NAME, polygon_id)
+        if polygon_id not in self._polygons_map:
+            return
+        self._store.delete_data(POLYGONS_MAP, polygon_id)
+
+    # ---- persistence (in-memory only) ------------------------------------
+
+    def save(self, path: str) -> None:
+        with open(path, 'wb') as fh:
+            pickle.dump({
+                'nodes': dict(self._nodes_map),
+                'edges': dict(self._edges_map),
+                'polygons': dict(self._polygons_map),
+            }, fh)
+
+    def load(self, path: str) -> None:
+        with open(path, 'rb') as fh:
+            data = pickle.load(fh)
+        self._nodes_map.clear()
+        self._edges_map.clear()
+        self._polygons_map.clear()
+        self._nodes_map.update(data.get('nodes', {}))
+        self._edges_map.update(data.get('edges', {}))
+        self._polygons_map.update(data.get('polygons', {}))
+        self._adjacency = {nid: set() for nid in self._nodes_map}
+        for eid, row in self._edges_map.items():
+            self._adjacency.setdefault(row['source'], set()).add(row['target'])
+
+
+class SqliteGraph(_GraphBase):
+    """SQLite-backed graph using a :class:`SqliteStore`."""
+
+    def __init__(self, store: SqliteStore):
+        self._store = store
+        store.create_map(NODES_MAP, {'id': int, 'x': float, 'y': float}, 'id')
+        store.create_map(
+            EDGES_MAP,
+            {
+                'id': int, 'source': int, 'target': int, 'length': float,
+                'geom': bytes,
+                'min_x': float, 'min_y': float, 'max_x': float, 'max_y': float,
+            },
+            'id',
+        )
+        store.create_map(
+            POLYGONS_MAP,
+            {
+                'id': int, 'coords': bytes, 'height': float, 'base': float,
+                'category': str, 'attributes': bytes,
+                'min_x': float, 'min_y': float, 'max_x': float, 'max_y': float,
+            },
+            'id',
+        )
+        store.create_index(NODES_MAP, ('x', 'y'))
+        store.create_index(EDGES_MAP, ('source', 'target'))
+        store.create_index(EDGES_MAP, ('min_x', 'min_y', 'max_x', 'max_y'),
+                           name=f'idx_{EDGES_MAP}_bbox')
+        store.create_index(POLYGONS_MAP, ('min_x', 'min_y', 'max_x', 'max_y'),
+                           name=f'idx_{POLYGONS_MAP}_bbox')
+        self._conn = store.connection()
+        self._tnodes = store.table_name(NODES_MAP)
+        self._tedges = store.table_name(EDGES_MAP)
+        self._tpolys = store.table_name(POLYGONS_MAP)
+
+    def _flush(self) -> None:
+        self._store.flush()
+
+    # ---- nodes -----------------------------------------------------------
+
+    def add_node(self, node_data: Dict[str, Any]) -> None:
+        node_id, x, y = self._validate_node_data(node_data)
+        try:
+            self._conn.execute(
+                f"INSERT INTO {self._tnodes} (\"id\", \"x\", \"y\") VALUES (?, ?, ?)",
+                (node_id, x, y),
+            )
+        except sqlite3.IntegrityError as exc:
+            if "UNIQUE constraint failed" in str(exc):
+                raise KeyError(f"Node {node_id} already exists.") from exc
+            raise
+        self._store.mark_dirty()
+
+    def update_node(self, node_data: Dict[str, Any]) -> None:
+        node_id, x, y = self._validate_node_data(node_data)
+        _ = self.get_node(node_id)
+        self._conn.execute(
+            f"UPDATE {self._tnodes} SET \"x\" = ?, \"y\" = ? WHERE \"id\" = ?",
+            (x, y, node_id),
+        )
+        self._store.mark_dirty()
+
+    def remove_node(self, node_id: int) -> None:
+        self._conn.execute(
+            f"DELETE FROM {self._tedges} WHERE \"source\" = ? OR \"target\" = ?",
+            (node_id, node_id),
+        )
+        self._conn.execute(f"DELETE FROM {self._tnodes} WHERE \"id\" = ?", (node_id,))
+        self._store.mark_dirty()
+
+    def get_node(self, node_id: int) -> Node:
+        self._flush()
+        cursor = self._conn.cursor()
+        cursor.execute(f"SELECT \"id\", \"x\", \"y\" FROM {self._tnodes} WHERE \"id\" = ?", (node_id,))
+        row = cursor.fetchone()
+        if row is None:
+            raise KeyError(f"Node {node_id} does not exist.")
+        return _mem_Node(id=row[0], x=row[1], y=row[2])
+
+    @overload
+    def get_nodes(self) -> Iterator[int]: ...
+    @overload
+    def get_nodes(self, d: float, x: float, y: float) -> Iterator[int]: ...
+    def get_nodes(self, d: float = -1.0, x: float = 0.0, y: float = 0.0) -> Iterator[int]:
+        self._flush()
+        cursor = self._conn.cursor()
+        if d >= 0:
+            cursor.execute(
+                f"SELECT \"id\" FROM {self._tnodes} WHERE \"x\" BETWEEN ? AND ? AND \"y\" BETWEEN ? AND ?",
+                (x - d, x + d, y - d, y + d),
+            )
+        else:
+            cursor.execute(f"SELECT \"id\" FROM {self._tnodes}")
+        while True:
+            row = cursor.fetchone()
+            if row is None:
+                break
+            yield row[0]
+
+    # ---- edges -----------------------------------------------------------
+
+    def _node_exists(self, node_id: int) -> bool:
+        cursor = self._conn.execute(
+            f"SELECT 1 FROM {self._tnodes} WHERE \"id\" = ?", (node_id,)
+        )
+        return cursor.fetchone() is not None
+
+    def add_edge(self, edge_data: Dict[str, Any]) -> None:
+        self._validate_edge_data(edge_data)
+        edge_id = int(edge_data['id'])
+        source = int(edge_data['source'])
+        target = int(edge_data['target'])
+        self._flush()
+        if not self._node_exists(source) or not self._node_exists(target):
+            raise KeyError(
+                f"Source or target node does not exist in the graph: {source}, {target}"
+            )
+        geom = self._normalize_linestring(edge_data, self.get_node)
+        bbox = self._edge_bbox_from_geom(geom)
+        try:
+            self._conn.execute(
+                f"INSERT INTO {self._tedges} (\"id\", \"source\", \"target\", \"length\", \"geom\", "
+                f"\"min_x\", \"min_y\", \"max_x\", \"max_y\") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (edge_id, source, target, float(edge_data['length']),
+                 cbor2.dumps(geom), bbox[0], bbox[1], bbox[2], bbox[3]),
+            )
+        except sqlite3.IntegrityError as exc:
+            if "UNIQUE constraint failed" in str(exc):
+                raise KeyError(f"Edge {edge_id} already exists.") from exc
+            raise
+        self._store.mark_dirty()
+
+    def update_edge(self, edge_data: Dict[str, Any]) -> None:
+        self._validate_edge_data(edge_data)
+        edge_id = int(edge_data['id'])
+        _ = self.get_edge(edge_id)
+        source = int(edge_data['source'])
+        target = int(edge_data['target'])
+        geom = self._normalize_linestring(edge_data, self.get_node)
+        bbox = self._edge_bbox_from_geom(geom)
+        self._conn.execute(
+            f"UPDATE {self._tedges} SET \"source\" = ?, \"target\" = ?, \"length\" = ?, \"geom\" = ?, "
+            f"\"min_x\" = ?, \"min_y\" = ?, \"max_x\" = ?, \"max_y\" = ? WHERE \"id\" = ?",
+            (source, target, float(edge_data['length']), cbor2.dumps(geom),
+             bbox[0], bbox[1], bbox[2], bbox[3], edge_id),
+        )
+        self._store.mark_dirty()
+
+    def remove_edge(self, edge_id: int) -> None:
+        self._conn.execute(f"DELETE FROM {self._tedges} WHERE \"id\" = ?", (edge_id,))
+        self._store.mark_dirty()
+
+    def get_edge(self, edge_id: int) -> OSMEdge:
+        self._flush()
+        cursor = self._conn.cursor()
+        cursor.execute(
+            f"SELECT \"id\", \"source\", \"target\", \"length\", \"geom\" FROM {self._tedges} WHERE \"id\" = ?",
+            (edge_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            raise KeyError(f"Edge {edge_id} does not exist.")
+        geom = tuple(tuple(c) for c in cbor2.loads(row[4]))
+        return _OSMEdge(row[0], row[1], row[2], row[3], geom)
+
+    @overload
+    def get_edges(self) -> Iterator[int]: ...
+    @overload
+    def get_edges(self, d: float, x: float, y: float) -> Iterator[int]: ...
+    def get_edges(self, d: float = -1.0, x: float = 0.0, y: float = 0.0) -> Iterator[int]:
+        self._flush()
+        cursor = self._conn.cursor()
+        if d >= 0:
+            x_min, x_max = x - d, x + d
+            y_min, y_max = y - d, y + d
+            cursor.execute(
+                f"SELECT \"id\" FROM {self._tedges} "
+                f"WHERE NOT (\"max_x\" < ? OR \"min_x\" > ? OR \"max_y\" < ? OR \"min_y\" > ?)",
+                (x_min, x_max, y_min, y_max),
+            )
+        else:
+            cursor.execute(f"SELECT \"id\" FROM {self._tedges}")
+        while True:
+            row = cursor.fetchone()
+            if row is None:
+                break
+            yield row[0]
+
+    def get_neighbors(self, node_id: int) -> Iterator[int]:
+        _ = self.get_node(node_id)
+        cursor = self._conn.cursor()
+        cursor.execute(f"SELECT \"target\" FROM {self._tedges} WHERE \"source\" = ?", (node_id,))
+        while True:
+            row = cursor.fetchone()
+            if row is None:
+                break
+            yield row[0]
+
+    # ---- polygons --------------------------------------------------------
+
+    def add_polygon(
+        self,
+        polygon_id: int,
+        coords: Any,
+        height: float = DEFAULT_BUILDING_HEIGHT,
+        base: float = 0.0,
+        category: str = "building",
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if height <= 0:
+            raise ValueError("Polygon height must be positive.")
+        normalized = _normalize_polygon_coords(coords)
+        bbox = _polygon_bbox(normalized)
+        try:
+            self._conn.execute(
+                f"INSERT INTO {self._tpolys} (\"id\", \"coords\", \"height\", \"base\", \"category\", "
+                f"\"attributes\", \"min_x\", \"min_y\", \"max_x\", \"max_y\") "
+                f"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (int(polygon_id), cbor2.dumps(normalized), float(height), float(base),
+                 str(category), cbor2.dumps(dict(attributes or {})),
+                 bbox[0], bbox[1], bbox[2], bbox[3]),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError(f"Polygon {polygon_id} already exists.") from exc
+        self._store.mark_dirty()
+
+    def get_polygon(self, polygon_id: int) -> Dict[str, Any]:
+        self._flush()
+        cursor = self._conn.cursor()
+        cursor.execute(
+            f"SELECT \"id\", \"coords\", \"height\", \"base\", \"category\", \"attributes\" "
+            f"FROM {self._tpolys} WHERE \"id\" = ?",
+            (polygon_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            raise KeyError(f"Polygon {polygon_id} does not exist.")
+        return {
+            'id': row[0],
+            'coords': [tuple(c) for c in cbor2.loads(row[1])],
+            'height': row[2],
+            'base': row[3],
+            'category': row[4],
+            'attributes': dict(cbor2.loads(row[5]) or {}),
+        }
+
+    @overload
+    def get_polygons(self) -> Iterator[int]: ...
+    @overload
+    def get_polygons(self, d: float, x: float, y: float) -> Iterator[int]: ...
+    def get_polygons(self, d: float = -1.0, x: float = 0.0, y: float = 0.0) -> Iterator[int]:
+        self._flush()
+        cursor = self._conn.cursor()
+        if d >= 0:
+            x_min, x_max = x - d, x + d
+            y_min, y_max = y - d, y + d
+            cursor.execute(
+                f"SELECT \"id\" FROM {self._tpolys} "
+                f"WHERE NOT (\"max_x\" < ? OR \"min_x\" > ? OR \"max_y\" < ? OR \"min_y\" > ?)",
+                (x_min, x_max, y_min, y_max),
+            )
+        else:
+            cursor.execute(f"SELECT \"id\" FROM {self._tpolys}")
+        while True:
+            row = cursor.fetchone()
+            if row is None:
+                break
+            yield row[0]
+
+    def remove_polygon(self, polygon_id: int) -> None:
+        self._conn.execute(f"DELETE FROM {self._tpolys} WHERE \"id\" = ?", (polygon_id,))
+        self._store.mark_dirty()
+
+
+class GraphEngine(IGraphEngine):
+    def __init__(self, ctx: IContext, engine: Enum = Engine.SQLITE):
+        self.ctx = ctx
+        self._engine_kind = engine
+        self._tempdir: Optional[tempfile.TemporaryDirectory] = None
+        ictx = getattr(self.ctx, 'ictx', None)
+        if ictx is None or ictx.memory is None:
+            raise RuntimeError(
+                "GraphEngine requires a memory engine. Initialise the context "
+                "via gamms.create_context()."
+            )
+        memory_engine = ictx.memory
+        if engine == Engine.MEMORY:
+            store = memory_engine.create_store(StoreType.MEMORY, GRAPH_STORE_NAME)
+            self._graph: _GraphBase = Graph(cast(MemoryStore, store))
+        elif engine == Engine.SQLITE:
+            self._tempdir = tempfile.TemporaryDirectory(dir='.')
+            db_path = PathLike(os.path.join(self._tempdir.name, 'graph.db'))
+            store = memory_engine.create_store(StoreType.DATABASE, GRAPH_STORE_NAME, db_path)
+            self._graph = SqliteGraph(cast(SqliteStore, store))
+        else:
+            raise ValueError(f"Unsupported engine type: {engine}")
+
+    @property
+    def graph(self) -> IGraph:
+        return self._graph
 
     def attach_networkx_graph(self, G: nx.Graph) -> IGraph:
-        """
-        Attaches a NetworkX graph to the Graph object.
-        """
         try:
             self._graph.attach_networkx_graph(G)
-        except Exception as e:
-            raise ValueError(f"Failed to attach NetworkX graph: {e}") from e
-        return self.graph
+        except Exception as exc:
+            raise ValueError(f"Failed to attach NetworkX graph: {exc}") from exc
+        return self._graph
+
+    def add_polygon(
+        self,
+        polygon_id: int,
+        coords: Any,
+        height: float = DEFAULT_BUILDING_HEIGHT,
+        base: float = 0.0,
+        category: str = "building",
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._graph.add_polygon(polygon_id, coords, height=height, base=base,
+                                category=category, attributes=attributes)
+
+    def get_polygon(self, polygon_id: int) -> Dict[str, Any]:
+        return self._graph.get_polygon(polygon_id)
+
+    @overload
+    def get_polygons(self) -> Iterator[int]: ...
+    @overload
+    def get_polygons(self, d: float, x: float, y: float) -> Iterator[int]: ...
+    def get_polygons(self, d: float = -1.0, x: float = 0.0, y: float = 0.0) -> Iterator[int]:
+        if d < 0:
+            return self._graph.get_polygons()
+        return self._graph.get_polygons(d, x, y)
+
+    def remove_polygon(self, polygon_id: int) -> None:
+        self._graph.remove_polygon(polygon_id)
 
     def load(self, path: str) -> IGraph:
-        """
-        Loads a graph from a file.
-        """
-        self._graph.load(path)
-        return self.graph
+        if hasattr(self._graph, 'load'):
+            self._graph.load(path)  # type: ignore[attr-defined]
+        else:
+            raise RuntimeError("load() is only supported by the in-memory Graph backend.")
+        return self._graph
 
-    def terminate(self):
+    def terminate(self) -> None:
         try:
-            del self._graph
-        except Exception as e:
-            print(f"Error during graph termination: {e}")
-        return
+            close = getattr(getattr(self._graph, '_store', None), 'close', None)
+            if callable(close):
+                close()
+        except Exception:
+            pass
+        if self._tempdir is not None:
+            try:
+                self._tempdir.cleanup()
+            except Exception:
+                pass
+            self._tempdir = None

--- a/gamms/MemoryEngine/memory_engine.py
+++ b/gamms/MemoryEngine/memory_engine.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, Iterator, Optional
 
 from gamms.typing.memory_engine import IMemoryEngine, IPathLike, IStore, StoreType
 from gamms.MemoryEngine.store import MemoryStore, PathLike, SqliteStore
@@ -7,8 +7,7 @@ from gamms.MemoryEngine.store import MemoryStore, PathLike, SqliteStore
 class MemoryEngine(IMemoryEngine):
     """Default :class:`IMemoryEngine` implementation.
 
-    The engine owns a registry of stores. Stores are created on demand and
-    each store carries its own backend (memory, sqlite, ...).
+    Owns a registry of stores, each of which carries its own backend.
     """
 
     def __init__(self) -> None:
@@ -27,8 +26,6 @@ class MemoryEngine(IMemoryEngine):
                 raise ValueError("DATABASE store requires a path.")
             return SqliteStore(name, path)  # type: ignore[arg-type]
         if store_type == StoreType.FILESYSTEM:
-            # Filesystem stores are not used for structured data and are
-            # intentionally limited to whole-store snapshots via MemoryStore.
             return MemoryStore(name, path)  # type: ignore[arg-type]
         raise ValueError(f"Unsupported store type: {store_type}")
 
@@ -39,44 +36,27 @@ class MemoryEngine(IMemoryEngine):
         path: Optional[IPathLike] = None,
     ) -> IStore:
         if name in self._stores:
-            raise ValueError(f"Store with name '{name}' already exists.")
+            raise ValueError(f"Store with name {name!r} already exists.")
         store = self._build_store(store_type, name, path)
         self._stores[name] = store
         return store
 
     def get_store(self, name: str) -> IStore:
         if name not in self._stores:
-            raise KeyError(f"Store with name '{name}' does not exist.")
+            raise KeyError(f"Store with name {name!r} does not exist.")
         return self._stores[name]
 
-    def list_stores(self) -> List[str]:
-        return list(self._stores.keys())
-
-    def load_store(
-        self,
-        store_type: StoreType,
-        name: str,
-        path: IPathLike,
-    ) -> IStore:
-        if name in self._stores:
-            return self._stores[name]
-        store = self._build_store(store_type, name, path)
-        store.load()
-        self._stores[name] = store
-        return store
-
-    def save_store(self, name: str, path: Optional[IPathLike] = None) -> None:
-        store = self.get_store(name)
-        if path is not None and hasattr(store, "_path"):
-            # Allow callers to redirect the snapshot location.
-            store._path = path  # type: ignore[attr-defined]
-        store.save()
+    def list_stores(self) -> Iterator[str]:
+        return iter(list(self._stores.keys()))
 
     def terminate(self) -> None:
         for store in self._stores.values():
             close = getattr(store, "close", None)
             if callable(close):
-                close()
+                try:
+                    close()
+                except Exception:
+                    pass
         self._stores.clear()
 
 

--- a/gamms/MemoryEngine/store.py
+++ b/gamms/MemoryEngine/store.py
@@ -1,18 +1,30 @@
+import json
 import os
-import pickle
 import sqlite3
-from typing import Any, Iterator, List, Optional, Type
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Type
+
+import cbor2
 
 from gamms.typing.memory_engine import IPathLike, IStore, StoreType
 
 
+_COLLECTION_TYPES = (list, tuple, dict, set)
+_PRIMITIVE_TYPES = (int, float, str, bool, bytes, type(None))
+_SUPPORTED_TYPES = _PRIMITIVE_TYPES + _COLLECTION_TYPES
+
+
 class PathLike(IPathLike):
-    """Concrete :class:`IPathLike` implementation backed by an absolute path."""
+    """Local filesystem resource locator.
+
+    ``IPathLike`` is intentionally generic so future implementations can
+    locate remote resources (carrying scheme/host/port). This concrete class
+    is the only one we ship today and treats ``path`` as an opaque string.
+    """
 
     def __init__(self, path: str):
         if not path:
             raise ValueError("Path cannot be empty.")
-        self.path = os.path.abspath(path)
+        self.path = path
 
     def exists(self) -> bool:
         return os.path.exists(self.path)
@@ -24,253 +36,475 @@ class PathLike(IPathLike):
         return f"PathLike({self.path!r})"
 
 
+def _validate_struct(struct: Dict[str, Type], primary_key: str) -> None:
+    if not isinstance(struct, dict) or not struct:
+        raise TypeError("struct must be a non-empty dict mapping field names to types.")
+    for field, field_type in struct.items():
+        if not isinstance(field, str) or not field:
+            raise TypeError(f"Field name must be a non-empty string, got {field!r}.")
+        if not isinstance(field_type, type):
+            raise TypeError(f"Field {field!r} type must be a Python type, got {field_type!r}.")
+        if field_type not in _SUPPORTED_TYPES:
+            raise TypeError(
+                f"Field {field!r} has unsupported type {field_type.__name__!r}."
+            )
+    if primary_key not in struct:
+        raise IndexError(f"Primary key {primary_key!r} not present in struct.")
+    if struct[primary_key] in _COLLECTION_TYPES:
+        raise IndexError(
+            f"Primary key {primary_key!r} must be an indexable scalar type, "
+            f"got {struct[primary_key].__name__!r}."
+        )
+
+
+def _coerce_field(field: str, field_type: Type, value: Any) -> Any:
+    if value is None and field_type is type(None):
+        return None
+    if isinstance(value, field_type):
+        return value
+    # Permit ints where floats are declared and vice-versa.
+    if field_type is float and isinstance(value, (int, bool)):
+        return float(value)
+    if field_type is int and isinstance(value, bool):
+        return int(value)
+    raise ValueError(
+        f"Field {field!r} expects {field_type.__name__}, got {type(value).__name__}."
+    )
+
+
 class MemoryStore(IStore):
-    """In-memory store backed by Python dictionaries."""
+    """In-memory ``IStore`` backed by Python dicts."""
 
     def __init__(self, name: str, path: Optional[PathLike] = None):
         self._name = name
         self._path = path
-        self._maps: dict = {}
-        self._types: dict = {}
+        self._maps: Dict[str, Dict[Any, Dict[str, Any]]] = {}
+        self._schemas: Dict[str, Tuple[Dict[str, Type], str]] = {}
 
-    @property
     def name(self) -> str:
         return self._name
 
-    @property
-    def store_type(self) -> StoreType:
-        return StoreType.MEMORY
-
-    @property
-    def path(self) -> Optional[PathLike]:
+    def path(self) -> Optional[IPathLike]:
         return self._path
 
-    def create_map(self, map_name: str, value_type: Optional[Type] = None) -> None:
-        if map_name in self._maps:
-            raise ValueError(f"Map '{map_name}' already exists in store '{self._name}'.")
-        self._maps[map_name] = {}
-        self._types[map_name] = value_type
+    @property
+    def type(self) -> StoreType:
+        return StoreType.MEMORY
 
-    def has_map(self, map_name: str) -> bool:
-        return map_name in self._maps
+    def create_map(self, map_name: str, struct: Dict[str, Type], primary_key: str) -> None:
+        if map_name in self._maps:
+            raise ValueError(f"Map {map_name!r} already exists in store {self._name!r}.")
+        _validate_struct(struct, primary_key)
+        self._maps[map_name] = {}
+        self._schemas[map_name] = (dict(struct), primary_key)
+
+    def delete_map(self, map_name: str) -> None:
+        if map_name not in self._maps:
+            raise KeyError(f"Map {map_name!r} does not exist in store {self._name!r}.")
+        del self._maps[map_name]
+        del self._schemas[map_name]
 
     def list_maps(self) -> List[str]:
         return list(self._maps.keys())
 
-    def _require_map(self, map_name: str) -> dict:
+    def _require_map(self, map_name: str) -> Tuple[Dict[Any, Dict[str, Any]], Dict[str, Type], str]:
         if map_name not in self._maps:
-            raise KeyError(f"Map '{map_name}' does not exist in store '{self._name}'.")
-        return self._maps[map_name]
+            raise KeyError(f"Map {map_name!r} does not exist in store {self._name!r}.")
+        struct, pk = self._schemas[map_name]
+        return self._maps[map_name], struct, pk
 
-    def insert_data(self, map_name: str, key: Any, value: Any) -> None:
-        m = self._require_map(map_name)
-        if key in m:
-            raise ValueError(f"Key {key!r} already exists in map '{map_name}'.")
-        m[key] = value
+    def _coerce_row(self, struct: Dict[str, Type], data: Dict[str, Any], partial: bool) -> Dict[str, Any]:
+        row: Dict[str, Any] = {}
+        for field, field_type in struct.items():
+            if field in data:
+                row[field] = _coerce_field(field, field_type, data[field])
+            elif not partial:
+                raise ValueError(f"Field {field!r} missing from struct.")
+        for field in data:
+            if field not in struct:
+                raise ValueError(f"Field {field!r} not declared in map schema.")
+        return row
 
-    def get_data(self, map_name: str, key: Any) -> Any:
-        m = self._require_map(map_name)
-        if key not in m:
-            raise KeyError(f"Key {key!r} not found in map '{map_name}'.")
-        return m[key]
+    def insert_data(self, map_name: str, struct: Dict[str, Any]) -> None:
+        rows, schema, pk = self._require_map(map_name)
+        if pk not in struct:
+            raise IndexError(f"Primary key {pk!r} missing from struct.")
+        row = self._coerce_row(schema, struct, partial=False)
+        key = row[pk]
+        if key in rows:
+            raise ValueError(f"Key {key!r} already exists in map {map_name!r}.")
+        rows[key] = row
 
-    def update_data(self, map_name: str, key: Any, value: Any) -> None:
-        m = self._require_map(map_name)
-        if key not in m:
-            raise KeyError(f"Key {key!r} not found in map '{map_name}'.")
-        m[key] = value
+    def get_data(self, map_name: str, key: Any) -> Tuple[Tuple[str, Any], ...]:
+        rows, schema, _ = self._require_map(map_name)
+        if key not in rows:
+            raise IndexError(f"Key {key!r} not found in map {map_name!r}.")
+        row = rows[key]
+        return tuple((field, row[field]) for field in schema.keys())
+
+    def update_data(self, map_name: str, struct: Dict[str, Any]) -> None:
+        rows, schema, pk = self._require_map(map_name)
+        if pk not in struct:
+            raise IndexError(f"Primary key {pk!r} missing from struct.")
+        key = struct[pk]
+        if key not in rows:
+            raise IndexError(f"Key {key!r} not found in map {map_name!r}.")
+        partial = self._coerce_row(schema, struct, partial=True)
+        rows[key].update(partial)
 
     def delete_data(self, map_name: str, key: Any) -> None:
-        m = self._require_map(map_name)
-        if key not in m:
-            raise KeyError(f"Key {key!r} not found in map '{map_name}'.")
-        del m[key]
+        rows, _, _ = self._require_map(map_name)
+        if key not in rows:
+            raise IndexError(f"Key {key!r} not found in map {map_name!r}.")
+        del rows[key]
 
-    def has_data(self, map_name: str, key: Any) -> bool:
-        return map_name in self._maps and key in self._maps[map_name]
+    def query_keys(self, map_name: str) -> Iterator[Any]:
+        rows, _, _ = self._require_map(map_name)
+        return iter(list(rows.keys()))
 
-    def keys(self, map_name: str) -> Iterator[Any]:
-        return iter(self._require_map(map_name).keys())
+    # ---- generic extension methods --------------------------------------
 
-    def items(self, map_name: str) -> Iterator[Any]:
-        return iter(self._require_map(map_name).items())
+    def create_index(self, map_name: str, fields: Sequence[str], name: Optional[str] = None) -> None:
+        # In-memory linear scans don't benefit from indexes; documented as a hint.
+        rows, schema, _ = self._require_map(map_name)
+        for field in fields:
+            if field not in schema:
+                raise ValueError(f"Cannot index unknown field {field!r} on map {map_name!r}.")
 
-    def save(self, obj: Any = None) -> None:
-        if obj is not None:
-            # Allow callers to overwrite the store with an explicit dict snapshot.
-            if not isinstance(obj, dict):
-                raise ValueError("MemoryStore.save expects a dict snapshot or None.")
-            self._maps = obj
-            return
-        if self._path is None:
-            return
-        os.makedirs(os.path.dirname(self._path.as_str()) or ".", exist_ok=True)
-        with open(self._path.as_str(), "wb") as fh:
-            pickle.dump({"maps": self._maps, "types": self._types}, fh)
+    def bulk_insert(self, map_name: str, rows: Iterable[Dict[str, Any]]) -> None:
+        for row in rows:
+            self.insert_data(map_name, row)
 
-    def load(self) -> Any:
-        if self._path is None:
-            return self._maps
-        if not self._path.exists():
-            raise FileNotFoundError(f"Store file '{self._path.as_str()}' does not exist.")
-        with open(self._path.as_str(), "rb") as fh:
-            data = pickle.load(fh)
-        self._maps = data.get("maps", {})
-        self._types = data.get("types", {})
-        return self._maps
+    def count(self, map_name: str) -> int:
+        rows, _, _ = self._require_map(map_name)
+        return len(rows)
 
-    def delete(self) -> None:
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
         self._maps.clear()
-        self._types.clear()
-        if self._path is not None and self._path.exists():
-            os.remove(self._path.as_str())
+        self._schemas.clear()
+
+    def get_map(self, map_name: str) -> Dict[Any, Dict[str, Any]]:
+        rows, _, _ = self._require_map(map_name)
+        return rows
+
+
+_PY_TO_SQL = {
+    int: "INTEGER",
+    float: "REAL",
+    str: "TEXT",
+    bool: "INTEGER",
+    bytes: "BLOB",
+    list: "BLOB",
+    tuple: "BLOB",
+    dict: "BLOB",
+    set: "BLOB",
+    type(None): "BLOB",
+}
+
+
+def _is_collection_type(t: Type) -> bool:
+    return t in _COLLECTION_TYPES
+
+
+def _safe_identifier(name: str) -> str:
+    if not name or not name.replace("_", "").isalnum():
+        raise ValueError(f"Invalid SQL identifier: {name!r}")
+    return name
 
 
 class SqliteStore(IStore):
-    """Store backed by a single SQLite database file.
-
-    Each "map" is mapped to its own table with two columns: ``key`` (primary
-    key, BLOB) and ``value`` (BLOB). Keys and values are pickled before being
-    persisted, which keeps the API agnostic to value type at the cost of
-    Python-only interoperability.
-    """
+    """SQLite-backed ``IStore``. Schemas map onto tables ``map_<name>``."""
 
     def __init__(self, name: str, path: PathLike):
         self._name = name
         self._path = path
-        os.makedirs(os.path.dirname(self._path.as_str()) or ".", exist_ok=True)
-        self._conn = sqlite3.connect(self._path.as_str(), isolation_level=None)
+        path_str = self._path.as_str()
+        if path_str != ":memory:":
+            parent = os.path.dirname(path_str)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+        self._conn = sqlite3.connect(path_str, isolation_level=None)
         self._conn.execute("PRAGMA journal_mode = WAL;")
+        self._conn.execute("PRAGMA temp_store = MEMORY;")
         self._conn.execute(
-            "CREATE TABLE IF NOT EXISTS _meta (map_name TEXT PRIMARY KEY, value_type TEXT)"
+            "CREATE TABLE IF NOT EXISTS _meta (map_name TEXT PRIMARY KEY, schema TEXT, primary_key TEXT)"
         )
-        self._maps_cache = set()
-        cursor = self._conn.execute("SELECT map_name FROM _meta")
-        for row in cursor.fetchall():
-            self._maps_cache.add(row[0])
+        self._schemas: Dict[str, Tuple[Dict[str, Type], str]] = {}
+        for map_name, schema_json, pk in self._conn.execute(
+            "SELECT map_name, schema, primary_key FROM _meta"
+        ).fetchall():
+            schema = self._decode_schema(schema_json)
+            self._schemas[map_name] = (schema, pk)
+        self._dirty = False
 
-    @property
     def name(self) -> str:
         return self._name
 
-    @property
-    def store_type(self) -> StoreType:
-        return StoreType.DATABASE
-
-    @property
     def path(self) -> PathLike:
         return self._path
 
+    @property
+    def type(self) -> StoreType:
+        return StoreType.DATABASE
+
     @staticmethod
-    def _table(map_name: str) -> str:
-        # Defensive: only allow safe table names.
-        if not map_name.replace("_", "").isalnum():
-            raise ValueError(f"Invalid map name: {map_name!r}")
-        return f"map_{map_name}"
+    def _encode_schema(struct: Dict[str, Type]) -> str:
+        return json.dumps([(field, ftype.__name__) for field, ftype in struct.items()])
 
-    def create_map(self, map_name: str, value_type: Optional[Type] = None) -> None:
-        if map_name in self._maps_cache:
-            raise ValueError(f"Map '{map_name}' already exists in store '{self._name}'.")
-        table = self._table(map_name)
-        self._conn.execute(
-            f"CREATE TABLE IF NOT EXISTS {table} (key BLOB PRIMARY KEY, value BLOB)"
-        )
-        self._conn.execute(
-            "INSERT OR REPLACE INTO _meta (map_name, value_type) VALUES (?, ?)",
-            (map_name, value_type.__name__ if value_type is not None else None),
-        )
-        self._maps_cache.add(map_name)
+    @staticmethod
+    def _decode_schema(blob: str) -> Dict[str, Type]:
+        type_lookup = {t.__name__: t for t in _SUPPORTED_TYPES}
+        type_lookup["NoneType"] = type(None)
+        return {field: type_lookup[name] for field, name in json.loads(blob)}
 
-    def has_map(self, map_name: str) -> bool:
-        return map_name in self._maps_cache
+    def table_name(self, map_name: str) -> str:
+        if map_name not in self._schemas:
+            raise KeyError(f"Map {map_name!r} does not exist in store {self._name!r}.")
+        return f"map_{_safe_identifier(map_name)}"
+
+    def quote_field(self, field: str) -> str:
+        return f'"{_safe_identifier(field)}"'
+
+    def connection(self) -> sqlite3.Connection:
+        return self._conn
+
+    def cursor(self) -> sqlite3.Cursor:
+        return self._conn.cursor()
+
+    def create_map(self, map_name: str, struct: Dict[str, Type], primary_key: str) -> None:
+        if map_name in self._schemas:
+            raise ValueError(f"Map {map_name!r} already exists in store {self._name!r}.")
+        _validate_struct(struct, primary_key)
+        _safe_identifier(map_name)
+        col_defs: List[str] = []
+        for field, field_type in struct.items():
+            sql_type = _PY_TO_SQL[field_type]
+            col_def = f"{self.quote_field(field)} {sql_type}"
+            if field == primary_key:
+                col_def += " PRIMARY KEY"
+            col_defs.append(col_def)
+        sql = f"CREATE TABLE IF NOT EXISTS {self.table_name_hint(map_name)} ({', '.join(col_defs)})"
+        self._conn.execute(sql)
+        self._conn.execute(
+            "INSERT OR REPLACE INTO _meta (map_name, schema, primary_key) VALUES (?, ?, ?)",
+            (map_name, self._encode_schema(struct), primary_key),
+        )
+        self._schemas[map_name] = (dict(struct), primary_key)
+
+    def table_name_hint(self, map_name: str) -> str:
+        # Internal helper: builds the table name without consulting _schemas
+        # (used during create_map before the schema is registered).
+        return f"map_{_safe_identifier(map_name)}"
+
+    def delete_map(self, map_name: str) -> None:
+        if map_name not in self._schemas:
+            raise KeyError(f"Map {map_name!r} does not exist in store {self._name!r}.")
+        self._conn.execute(f"DROP TABLE IF EXISTS {self.table_name(map_name)}")
+        self._conn.execute("DELETE FROM _meta WHERE map_name = ?", (map_name,))
+        del self._schemas[map_name]
 
     def list_maps(self) -> List[str]:
-        return list(self._maps_cache)
+        return list(self._schemas.keys())
 
-    def _require_map(self, map_name: str) -> str:
-        if map_name not in self._maps_cache:
-            raise KeyError(f"Map '{map_name}' does not exist in store '{self._name}'.")
-        return self._table(map_name)
+    def _require_schema(self, map_name: str) -> Tuple[Dict[str, Type], str]:
+        if map_name not in self._schemas:
+            raise KeyError(f"Map {map_name!r} does not exist in store {self._name!r}.")
+        return self._schemas[map_name]
 
-    def insert_data(self, map_name: str, key: Any, value: Any) -> None:
-        table = self._require_map(map_name)
-        kb, vb = pickle.dumps(key), pickle.dumps(value)
+    def _encode_value(self, field_type: Type, value: Any) -> Any:
+        if value is None:
+            return None
+        coerced = _coerce_field("<value>", field_type, value)
+        if _is_collection_type(field_type):
+            return cbor2.dumps(coerced if not isinstance(coerced, set) else list(coerced))
+        if field_type is bool:
+            return 1 if coerced else 0
+        return coerced
+
+    def _decode_value(self, field_type: Type, raw: Any) -> Any:
+        if raw is None:
+            return None
+        if _is_collection_type(field_type):
+            decoded = cbor2.loads(raw)
+            if field_type is tuple:
+                return _to_tuple_recursive(decoded)
+            if field_type is set:
+                return set(decoded)
+            return decoded
+        if field_type is bool:
+            return bool(raw)
+        return raw
+
+    def _build_row_payload(
+        self, schema: Dict[str, Type], data: Dict[str, Any], partial: bool
+    ) -> Dict[str, Any]:
+        for field in data:
+            if field not in schema:
+                raise ValueError(f"Field {field!r} not declared in map schema.")
+        payload: Dict[str, Any] = {}
+        for field, field_type in schema.items():
+            if field in data:
+                payload[field] = self._encode_value(field_type, data[field])
+            elif not partial:
+                raise ValueError(f"Field {field!r} missing from struct.")
+        return payload
+
+    def insert_data(self, map_name: str, struct: Dict[str, Any]) -> None:
+        schema, pk = self._require_schema(map_name)
+        if pk not in struct:
+            raise IndexError(f"Primary key {pk!r} missing from struct.")
+        payload = self._build_row_payload(schema, struct, partial=False)
+        cols = ", ".join(self.quote_field(f) for f in payload.keys())
+        placeholders = ", ".join("?" for _ in payload)
         try:
-            self._conn.execute(f"INSERT INTO {table} (key, value) VALUES (?, ?)", (kb, vb))
+            self._conn.execute(
+                f"INSERT INTO {self.table_name(map_name)} ({cols}) VALUES ({placeholders})",
+                tuple(payload.values()),
+            )
         except sqlite3.IntegrityError as exc:
-            raise ValueError(f"Key {key!r} already exists in map '{map_name}'.") from exc
+            raise ValueError(f"Key {struct[pk]!r} already exists in map {map_name!r}.") from exc
+        self._dirty = True
 
-    def get_data(self, map_name: str, key: Any) -> Any:
-        table = self._require_map(map_name)
-        cursor = self._conn.execute(f"SELECT value FROM {table} WHERE key = ?", (pickle.dumps(key),))
+    def get_data(self, map_name: str, key: Any) -> Tuple[Tuple[str, Any], ...]:
+        schema, pk = self._require_schema(map_name)
+        self.flush()
+        cols = ", ".join(self.quote_field(f) for f in schema.keys())
+        cursor = self._conn.execute(
+            f"SELECT {cols} FROM {self.table_name(map_name)} WHERE {self.quote_field(pk)} = ?",
+            (self._encode_value(schema[pk], key),),
+        )
         row = cursor.fetchone()
         if row is None:
-            raise KeyError(f"Key {key!r} not found in map '{map_name}'.")
-        return pickle.loads(row[0])
-
-    def update_data(self, map_name: str, key: Any, value: Any) -> None:
-        table = self._require_map(map_name)
-        kb = pickle.dumps(key)
-        cursor = self._conn.execute(f"SELECT 1 FROM {table} WHERE key = ?", (kb,))
-        if cursor.fetchone() is None:
-            raise KeyError(f"Key {key!r} not found in map '{map_name}'.")
-        self._conn.execute(
-            f"UPDATE {table} SET value = ? WHERE key = ?", (pickle.dumps(value), kb)
+            raise IndexError(f"Key {key!r} not found in map {map_name!r}.")
+        return tuple(
+            (field, self._decode_value(schema[field], raw))
+            for field, raw in zip(schema.keys(), row)
         )
 
-    def delete_data(self, map_name: str, key: Any) -> None:
-        table = self._require_map(map_name)
-        kb = pickle.dumps(key)
-        cursor = self._conn.execute(f"SELECT 1 FROM {table} WHERE key = ?", (kb,))
+    def update_data(self, map_name: str, struct: Dict[str, Any]) -> None:
+        schema, pk = self._require_schema(map_name)
+        if pk not in struct:
+            raise IndexError(f"Primary key {pk!r} missing from struct.")
+        key = struct[pk]
+        self.flush()
+        cursor = self._conn.execute(
+            f"SELECT 1 FROM {self.table_name(map_name)} WHERE {self.quote_field(pk)} = ?",
+            (self._encode_value(schema[pk], key),),
+        )
         if cursor.fetchone() is None:
-            raise KeyError(f"Key {key!r} not found in map '{map_name}'.")
-        self._conn.execute(f"DELETE FROM {table} WHERE key = ?", (kb,))
+            raise IndexError(f"Key {key!r} not found in map {map_name!r}.")
+        payload = self._build_row_payload(schema, struct, partial=True)
+        update_fields = [f for f in payload.keys() if f != pk]
+        if not update_fields:
+            return
+        assignments = ", ".join(f"{self.quote_field(f)} = ?" for f in update_fields)
+        params = tuple(payload[f] for f in update_fields) + (self._encode_value(schema[pk], key),)
+        self._conn.execute(
+            f"UPDATE {self.table_name(map_name)} SET {assignments} WHERE {self.quote_field(pk)} = ?",
+            params,
+        )
+        self._dirty = True
 
-    def has_data(self, map_name: str, key: Any) -> bool:
-        if map_name not in self._maps_cache:
-            return False
-        table = self._table(map_name)
-        cursor = self._conn.execute(f"SELECT 1 FROM {table} WHERE key = ?", (pickle.dumps(key),))
-        return cursor.fetchone() is not None
+    def delete_data(self, map_name: str, key: Any) -> None:
+        schema, pk = self._require_schema(map_name)
+        self.flush()
+        cursor = self._conn.execute(
+            f"SELECT 1 FROM {self.table_name(map_name)} WHERE {self.quote_field(pk)} = ?",
+            (self._encode_value(schema[pk], key),),
+        )
+        if cursor.fetchone() is None:
+            raise IndexError(f"Key {key!r} not found in map {map_name!r}.")
+        self._conn.execute(
+            f"DELETE FROM {self.table_name(map_name)} WHERE {self.quote_field(pk)} = ?",
+            (self._encode_value(schema[pk], key),),
+        )
+        self._dirty = True
 
-    def keys(self, map_name: str) -> Iterator[Any]:
-        table = self._require_map(map_name)
-        cursor = self._conn.execute(f"SELECT key FROM {table}")
+    def query_keys(self, map_name: str) -> Iterator[Any]:
+        schema, pk = self._require_schema(map_name)
+        self.flush()
+        cursor = self._conn.execute(
+            f"SELECT {self.quote_field(pk)} FROM {self.table_name(map_name)}"
+        )
+        pk_type = schema[pk]
         while True:
             row = cursor.fetchone()
             if row is None:
                 break
-            yield pickle.loads(row[0])
+            yield self._decode_value(pk_type, row[0])
 
-    def items(self, map_name: str) -> Iterator[Any]:
-        table = self._require_map(map_name)
-        cursor = self._conn.execute(f"SELECT key, value FROM {table}")
-        while True:
-            row = cursor.fetchone()
-            if row is None:
-                break
-            yield pickle.loads(row[0]), pickle.loads(row[1])
+    # ---- generic extension methods --------------------------------------
 
-    def save(self, obj: Any = None) -> None:
-        # SQLite stores autocommit on each statement; nothing to do.
-        return
+    def create_index(self, map_name: str, fields: Sequence[str], name: Optional[str] = None) -> None:
+        schema, _ = self._require_schema(map_name)
+        for field in fields:
+            if field not in schema:
+                raise ValueError(f"Cannot index unknown field {field!r} on map {map_name!r}.")
+        index_name = name or f"idx_{_safe_identifier(map_name)}_{'_'.join(_safe_identifier(f) for f in fields)}"
+        cols = ", ".join(self.quote_field(f) for f in fields)
+        self._conn.execute(
+            f"CREATE INDEX IF NOT EXISTS {_safe_identifier(index_name)} ON {self.table_name(map_name)} ({cols})"
+        )
 
-    def load(self) -> Any:
-        # Load is a no-op once the connection is open. Return a snapshot for
-        # callers that want the materialised contents.
-        snapshot = {}
-        for map_name in self._maps_cache:
-            snapshot[map_name] = dict(self.items(map_name))
-        return snapshot
+    def bulk_insert(self, map_name: str, rows: Iterable[Dict[str, Any]]) -> None:
+        schema, pk = self._require_schema(map_name)
+        rows = list(rows)
+        if not rows:
+            return
+        ordered_fields = list(schema.keys())
+        cols = ", ".join(self.quote_field(f) for f in ordered_fields)
+        placeholders = ", ".join("?" for _ in ordered_fields)
+        params_list = []
+        for row in rows:
+            if pk not in row:
+                raise IndexError(f"Primary key {pk!r} missing from struct.")
+            payload = self._build_row_payload(schema, row, partial=False)
+            params_list.append(tuple(payload[f] for f in ordered_fields))
+        try:
+            self._conn.executemany(
+                f"INSERT INTO {self.table_name(map_name)} ({cols}) VALUES ({placeholders})",
+                params_list,
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError(f"Duplicate key during bulk_insert into map {map_name!r}.") from exc
+        self._dirty = True
 
-    def delete(self) -> None:
-        for map_name in list(self._maps_cache):
-            self._conn.execute(f"DROP TABLE IF EXISTS {self._table(map_name)}")
-        self._conn.execute("DELETE FROM _meta")
-        self._maps_cache.clear()
+    def count(self, map_name: str) -> int:
+        self._require_schema(map_name)
+        self.flush()
+        cursor = self._conn.execute(f"SELECT COUNT(*) FROM {self.table_name(map_name)}")
+        return cursor.fetchone()[0]
+
+    def flush(self) -> None:
+        if self._dirty:
+            self._conn.commit()
+            self._dirty = False
+
+    def mark_dirty(self) -> None:
+        """Mark pending writes that bypassed the IStore API.
+
+        Consumers using ``connection()`` / ``cursor()`` directly should call
+        this so subsequent reads ``flush()`` first.
+        """
+        self._dirty = True
 
     def close(self) -> None:
+        try:
+            self.flush()
+        except Exception:
+            pass
         try:
             self._conn.close()
         except Exception:
             pass
+
+
+def _to_tuple_recursive(value: Any) -> Any:
+    if isinstance(value, list):
+        return tuple(_to_tuple_recursive(v) for v in value)
+    if isinstance(value, tuple):
+        return tuple(_to_tuple_recursive(v) for v in value)
+    return value

--- a/gamms/SensorEngine/sensor_engine.py
+++ b/gamms/SensorEngine/sensor_engine.py
@@ -1,632 +1,32 @@
-from gamms.typing import(
+"""SensorEngine factory.
+
+The actual sensor classes live in:
+- ``sensors_basic`` — NeighborSensor, MapSensor, AgentSensor
+- ``sensors_aerial`` — AerialSensor, AerialAgentSensor
+- ``sensors_occluded`` — OccludedMapSensor, OccludedAgentSensor,
+  OccludedAerialSensor, OccludedAerialAgentSensor (one general class per axis;
+  ARC/RANGE variants are factory presets only).
+"""
+
+import math
+from typing import Any, Callable, Dict, cast
+
+from aenum import extend_enum
+
+from gamms.typing import (
     IContext,
     ISensor,
     ISensorEngine,
     SensorType,
-    Node,
-    OSMEdge,
-    AgentType,
-    IAerialAgent
 )
-
-from gamms.SensorEngine.occlusion import segment_blocked_by_polygon
-
-from typing import Any, Dict, Iterable, Iterator, Optional, Callable, Tuple, List, Union, cast
-from aenum import extend_enum
-import math
-
-
-def _iter_polygon_records(ctx: IContext) -> Iterator[Dict[str, Any]]:
-    """Yield polygon records from the graph engine's polygon store, if any."""
-    graph_engine = ctx.graph
-    if graph_engine is None:
-        return
-    get_polygons = getattr(graph_engine, "get_polygons", None)
-    get_polygon = getattr(graph_engine, "get_polygon", None)
-    if not callable(get_polygons) or not callable(get_polygon):
-        return
-    try:
-        ids = list(get_polygons())
-    except RuntimeError:
-        return
-    for pid in ids:
-        try:
-            yield get_polygon(pid)
-        except KeyError:
-            continue
-
-
-def _is_segment_occluded(
-    ctx: IContext,
-    a: Tuple[float, float, float],
-    b: Tuple[float, float, float],
-    polygons: Optional[Iterable[Dict[str, Any]]] = None,
-) -> bool:
-    """True if any polygon on the graph engine blocks the segment a-b."""
-    if polygons is None:
-        polygons = _iter_polygon_records(ctx)
-    for poly in polygons:
-        if segment_blocked_by_polygon(
-            a, b, poly["coords"], poly.get("base", 0.0), poly["height"]
-        ):
-            return True
-    return False
-
-class NeighborSensor(ISensor):
-    def __init__(self, ctx: IContext, sensor_id: str, sensor_type: SensorType):
-        self._sensor_id = sensor_id
-        self.ctx = ctx
-        self._type = sensor_type
-        self._data = []
-        self._owner = None
-    
-    @property
-    def sensor_id(self) -> str:
-        return self._sensor_id
-    
-    @property
-    def type(self) -> SensorType:
-        return self._type
-
-    @property
-    def data(self):
-        return self._data
-    
-    def set_owner(self, owner: Union[str, None]) -> None:
-        self._owner = owner
-
-    def sense(self, node_id: int) -> None:
-        nearest_neighbors = {node_id,}
-        for nid in self.ctx.graph.graph.get_neighbors(node_id):
-            nearest_neighbors.add(nid)
-
-        self._data = list(nearest_neighbors)
-
-    def update(self, data: Dict[str, Any]) -> None:
-        pass
-
-class MapSensor(ISensor):
-    def __init__(self, ctx: IContext, sensor_id: str, sensor_type: SensorType, sensor_range: float, fov: float, orientation: Tuple[float, float] = (1.0, 0.0)):
-        """
-        Acts as a map sensor (if sensor_range == inf),
-        a range sensor (if fov == 2*pi),
-        or a unidirectional sensor (if fov < 2*pi).
-        Assumes fov and orientation are provided in radians.
-        """
-        self.ctx = ctx
-        self._sensor_id = sensor_id
-        self._type = sensor_type
-        self.range = sensor_range
-        self.fov = fov  
-        norm = math.sqrt(orientation[0]**2 + orientation[1]**2)
-        self.orientation = (orientation[0] / norm, orientation[1] / norm)
-        self._data: Dict[str, Union[Dict[int, Node], List[OSMEdge]]] = {}
-        # Cache static node IDs and positions.
-        self._owner = None
-    
-    @property
-    def sensor_id(self) -> str:
-        return self._sensor_id
-    
-    @property
-    def type(self) -> SensorType:
-        return self._type
-
-    @property
-    def data(self) -> Dict[str, Union[Dict[int, Node],List[OSMEdge]]]:
-        return self._data
-    
-    def set_owner(self, owner: Union[str, None]) -> None:
-        self._owner = owner
-
-    def sense(self, node_id: int) -> None:
-        """
-        Detects nodes within the sensor range and arc.
-        
-        The result is now stored in self._data as a dictionary with two keys:
-          - 'nodes': {node_id: node, ...} for nodes that pass the sensing filter.
-          - 'edges': List of edges visible from all sensed nodes.
-        """
-        current_node = self.ctx.graph.graph.get_node(node_id)
-        if self._owner is not None:
-            # Fetch the owner's orientation from the agent engine.
-            orientation_used = self.ctx.agent.get_agent(self._owner).orientation
-            # Complex multiplication to rotate the orientation vector.
-            orientation_used = (
-                self.orientation[0]*orientation_used[0] - self.orientation[1]*orientation_used[1], 
-                self.orientation[0]*orientation_used[1] + self.orientation[1]*orientation_used[0]
-            )
-        else:
-            orientation_used = self.orientation
-        
-        if self.range == float('inf'):
-            edge_iter = self.ctx.graph.graph.get_edges()
-        else:
-            edge_iter = self.ctx.graph.graph.get_edges(d=self.range, x=current_node.x, y=current_node.y)
-
-
-        sensed_nodes: Dict[int, Node] = {}
-        sensed_edges: List[OSMEdge] = []
-
-        for edge_id in edge_iter:
-            edge = self.ctx.graph.graph.get_edge(edge_id)
-            source = self.ctx.graph.graph.get_node(edge.source)
-            target = self.ctx.graph.graph.get_node(edge.target)
-            sbool = (source.x - current_node.x)**2 + (source.y - current_node.y)**2 <= self.range**2
-            tbool = (target.x - current_node.x)**2 + (target.y - current_node.y)**2 <= self.range**2
-            if not (self.fov == 2 * math.pi or orientation_used == (0.0, 0.0)):
-                angle = math.atan2(source.y - current_node.y, source.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
-                angle = angle % (2 * math.pi)
-                angle = angle - math.pi
-                sbool &= (
-                    abs(angle) <= self.fov / 2
-                ) or (source.id == node_id)
-                angle = math.atan2(target.y - current_node.y, target.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
-                angle = angle % (2 * math.pi)
-                angle = angle - math.pi
-                tbool &= (
-                    abs(angle) <= self.fov / 2
-                ) or (target.id == node_id)
-            if sbool:
-                sensed_nodes[source.id] = source
-            if tbool:
-                sensed_nodes[target.id] = target
-            if sbool and tbool:
-                sensed_edges.append(edge)
-
-        self._data = {'nodes': sensed_nodes, 'edges': sensed_edges}
-
-    def update(self, data: Dict[str, Any]) -> None:
-        # No dynamic updates required for this sensor.
-        pass
-
-class AgentSensor(ISensor):
-    def __init__(
-        self, 
-        ctx: IContext, 
-        sensor_id: str, 
-        sensor_type: SensorType, 
-        sensor_range: float, 
-        fov: float = 2 * math.pi, 
-        orientation: Tuple[float, float] = (1.0, 0.0), 
-        owner: Optional[str] = None
-    ):
-        """
-        Detects other agents within a specified range and field of view.
-        :param agent_engine: Typically the context's agent engine.
-        :param sensor_range: Maximum detection distance for agents.
-        :param fov: Field of view in radians. Use 2*pi for no angular filtering.
-        :param orientation: Default orientation (in radians) if no owner is set.
-        :param owner: (Optional) The name of the agent owning this sensor.
-                      This agent will be skipped during sensing.
-        """
-        self._sensor_id = sensor_id
-        self.ctx = ctx
-        self._type = sensor_type
-        self.range = sensor_range
-        self.fov = fov              
-        self.orientation = orientation  
-        self._owner = owner
-        self._data: Dict[str, int] = {}
-    
-
-    @property
-    def sensor_id(self) -> str:
-        return self._sensor_id
-    
-    @property
-    def type(self) -> SensorType:
-        return self._type
-
-    @property
-    def data(self) -> Dict[str, int]:
-        return self._data
-
-    def set_owner(self, owner: Union[str, None]) -> None:
-        self._owner = owner
-        
-    def sense(self, node_id: int) -> None:
-        """
-        Detects agents within the sensor range of the sensing node.
-        Skips the agent whose name matches self._owner.
-        In addition to a range check, if self.fov != 2*pi, only agents within (fov/2) radians
-        of the chosen orientation are included.
-        The chosen orientation is determined as follows:
-         - If self._owner is set, fetch the owner's orientation from the agent engine.
-         - Otherwise, use self.orientation.
-        The result is stored in self._data as a dictionary mapping agent names to agent objects.
-        """
-        # Get current node position as sensing origin.
-        current_node = self.ctx.graph.graph.get_node(node_id)
-
-        if self._owner is not None:
-            # Fetch the owner's orientation from the agent engine.
-            orientation_used = self.ctx.agent.get_agent(self._owner).orientation
-            # Complex multiplication to rotate the orientation vector.
-            orientation_used = (
-                self.orientation[0]*orientation_used[0] - self.orientation[1]*orientation_used[1], 
-                self.orientation[0]*orientation_used[1] + self.orientation[1]*orientation_used[0]
-            )
-        else:
-            orientation_used = self.orientation
-
-        sensed_agents = {}
-
-        # Collect positions and ids for all agents except the owner.
-        for agent in self.ctx.agent.create_iter():
-            if agent.name == self._owner:
-                continue
-            
-            agent_node = self.ctx.graph.graph.get_node(agent.current_node_id)
-            distance = (agent_node.x - current_node.x)**2 + (agent_node.y - current_node.y)**2
-            
-            if distance <= self.range**2:
-                if self.fov == 2 * math.pi or orientation_used == (0.0, 0.0):
-                    sensed_agents[agent.name] = agent.current_node_id
-                else:
-                    angle = math.atan2(agent_node.y - current_node.y, agent_node.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
-                    angle = angle % (2 * math.pi)
-                    angle = angle - math.pi
-                    if abs(angle) <= self.fov / 2 or agent.current_node_id == node_id:
-                        sensed_agents[agent.name] = agent.current_node_id
-
-        self._data = sensed_agents
-
-    def update(self, data: Dict[str, Any]) -> None:
-        # No dynamic updates required for this sensor.
-        pass
-
-def multiply_quaternions(q1: Tuple[float, float, float, float], q2: Tuple[float, float, float, float]) -> Tuple[float, float, float, float]:
-    w1, x1, y1, z1 = q1
-    w2, x2, y2, z2 = q2
-    return (
-        w1*w2 - x1*x2 - y1*y2 - z1*z2,
-        w1*x2 + x1*w2 + y1*z2 - z1*y2,
-        w1*y2 - x1*z2 + y1*w2 + z1*x2,
-        w1*z2 + x1*y2 - y1*x2 + z1*w2
-    )
-
-def quaternion_to_direction(quat: Tuple[float, float, float, float]) -> Tuple[float, float, float]:
-    w, x, y, z = quat
-    # Convert quaternion to direction vector (assuming forward is along the x-axis)
-    return (
-        1 - 2*(y**2 + z**2),
-        2*(x*y + w*z),
-        2*(x*z - w*y)
-    )
-
-class AerialSensor(ISensor):
-    def __init__(
-        self,
-        ctx: IContext,
-        sensor_id: str,
-        sensor_range: float,
-        fov: float = math.pi / 3,
-        quat: Tuple[float, float, float, float] = (math.sqrt(0.5), 0.0, math.sqrt(0.5), 0.0)
-    ):  # Default 60° FOV
-        """
-        Downward-facing conic sensor for aerial agents.
-        
-        Args:
-            sensor_range: Maximum slant distance from drone to detected point
-            fov: Field of view angle in radians (half-angle of cone)
-        """
-        self._sensor_id = sensor_id
-        self.ctx = ctx
-        self._data: Dict[str, Union[Dict[int, Node], List[OSMEdge]]] = {}
-        self._owner = None
-        self.range = sensor_range
-        self.fov = min(fov, math.pi * 0.9)  # Cap at ~162° to avoid backward vision
-        self.quat = quat
-
-    @property
-    def sensor_id(self) -> str:
-        return self._sensor_id
-    
-    @property
-    def type(self) -> SensorType:
-        return SensorType.AERIAL
-
-    @property
-    def data(self) -> Dict[str, Union[Dict[int, Node], List[OSMEdge]]]:
-        return self._data
-    
-    def set_owner(self, owner: Union[str, None]) -> None:
-        if owner is not None:
-            agent = self.ctx.agent.get_agent(owner)
-            if agent.type != AgentType.AERIAL:
-                raise ValueError("Owner of AerialSensor must be an aerial agent")
-        self._owner = owner
-
-    def sense(self, node_id: int) -> None:
-        """
-        Detect nodes within the conic field of view from the drone's position.
-        
-        Args:
-            node_id: Current node (may not be used if drone is airborne)
-        """        
-        # If no owner, return empty
-        if self._owner is None:
-            self._data = {'nodes': {}, 'edges': []}
-            return
-        agent = cast(IAerialAgent, self.ctx.agent.get_agent(self._owner))
-
-        # Multiply agent orientation by sensor quaternion
-        orientation = multiply_quaternions(agent.quat, self.quat)
-        # Convert to Euler angles to extract pitch
-        fx, fy, fz = quaternion_to_direction(orientation)
-
-        pos = agent.position
-                
-        x, y, z = pos
-        
-        # Calculate the radius of visibility on the ground
-        # Based on cone geometry and sensor range constraints
-        half_angle = self.fov / 2
-
-        sensed_nodes: Dict[int, Node] = {}
-        sensed_edges: List[OSMEdge] = []
-
-        for edge_id in self.ctx.graph.graph.get_edges(d=self.range, x=x, y=y):
-            edge = self.ctx.graph.graph.get_edge(edge_id)
-            source = self.ctx.graph.graph.get_node(edge.source)
-            target = self.ctx.graph.graph.get_node(edge.target)
-            # Check if either endpoint is within range
-            normsq = (source.x - x)**2 + (source.y - y)**2 + z**2
-            cosine = (source.x - x) * fx + (source.y - y) * fy - z * fz
-            angle = math.acos(max(min(cosine/math.sqrt(normsq), 1.0), -1.0)) if normsq != 0 else 2*math.pi
-            sbool = (normsq <= self.range**2) and (angle <= half_angle)
-            normsq = (target.x - x)**2 + (target.y - y)**2 + z**2
-            cosine = (target.x - x) * fx + (target.y - y) * fy - z * fz
-            angle = math.acos(max(min(cosine/math.sqrt(normsq), 1.0), -1.0)) if normsq != 0 else 2*math.pi
-            tbool = (normsq <= self.range**2) and (angle <= half_angle)
-            # Check if angle between node vector and downward vertical is within FOV
-            if sbool:
-                sensed_nodes[source.id] = source
-            if tbool:
-                sensed_nodes[target.id] = target
-            if sbool and tbool:
-                sensed_edges.append(edge)
-        
-        self._data = {'nodes': sensed_nodes, 'edges': sensed_edges}
-
-    def update(self, data: Dict[str, Any]) -> None:
-        pass
-
-
-class AerialAgentSensor(ISensor):
-    def __init__(
-        self, 
-        ctx: IContext, 
-        sensor_id: str, 
-        sensor_range: float, 
-        fov: float = 2 * math.pi, 
-        quat: Tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
-    ):
-        """
-        Detects other aerial agents within a specified 3D range and field of view.
-        Similar to AgentSensor but works in 3D space for aerial agents.
-        
-        Args:
-            sensor_range: Maximum detection distance for agents
-            fov: Field of view in radians. Use 2*pi for no angular filtering
-            quat: Default quaternion (w, x, y, z) if no owner is set
-        """
-        self._sensor_id = sensor_id
-        self.ctx = ctx
-        self.range = sensor_range
-        self.fov = fov              
-        self.quat = quat  
-        self._owner = None
-        self._data: Dict[str, Tuple[AgentType, Tuple[float, float, float]]] = {}
-    
-    @property
-    def sensor_id(self) -> str:
-        return self._sensor_id
-    
-    @property
-    def type(self) -> SensorType:
-        return SensorType.AERIAL_AGENT
-
-    @property
-    def data(self) -> Dict[str, Tuple[float, float, float]]:
-        return self._data
-
-    def set_owner(self, owner: Union[str, None]) -> None:
-        agent = self.ctx.agent.get_agent(owner) if owner else None
-        if agent is not None:
-            if agent.type != AgentType.AERIAL:
-                raise ValueError("Owner of AerialAgentSensor must be an aerial agent")
-        self._owner = owner
-            
-    def sense(self, node_id: int) -> None:
-        """
-        Detects agents within the sensor range in 3D space.
-        Returns agent positions instead of node IDs for aerial agents.
-        """
-        # Get sensing position
-        if self._owner is None:
-            self._data = {}
-            return
-        agent = cast(IAerialAgent, self.ctx.agent.get_agent(self._owner))
-        quat = multiply_quaternions(agent.quat, self.quat)
-        fx, fy, fz = quaternion_to_direction(quat)
-
-        x, y, z = agent.position
-
-        sensed_agents = {}
-
-        # Check all agents except the owner
-        for agent in self.ctx.agent.create_iter():
-            if agent.name == self._owner:
-                continue
-            
-            # Get agent position
-            if agent.type == AgentType.AERIAL:
-                agent_pos = cast(IAerialAgent, agent).position
-            elif agent.type == AgentType.BASIC:
-                agent_node = self.ctx.graph.graph.get_node(agent.current_node_id)
-                agent_pos = (agent_node.x, agent_node.y, 0.0)
-            else:
-                raise RuntimeError(f"Unknown agent type {agent.type} for agent {agent.name}")
-            
-            # Calculate 3D distance
-            dx = agent_pos[0] - x
-            dy = agent_pos[1] - y
-            dz = agent_pos[2] - z
-            distance_3d = dx**2 + dy**2 + dz**2
-
-            cosine = dx * fx + dy * fy + dz * fz
-            angle = math.acos(max(min(cosine/math.sqrt(distance_3d), 1.0), -1.0)) if distance_3d != 0 else 2*math.pi
-            # Check range and FOV
-            agent_bool = (distance_3d <= self.range**2) and (angle <= self.fov / 2)
-
-            if agent_bool:
-                sensed_agents[agent.name] = (agent.type, agent_pos)
-
-        self._data = sensed_agents
-
-    def update(self, data: Dict[str, Any]) -> None:
-        pass
-
-class OccludedMapSensor(MapSensor):
-    """:class:`MapSensor` variant that drops nodes/edges occluded by polygons.
-
-    Sensor rays originate from the sensing position (the current node, or the
-    aerial agent's 3D position when an aerial owner is set). A node is kept
-    only if the ray to it is not blocked by any polygon prism registered with
-    the graph engine. Edges are kept only if both endpoints survive.
-
-    ``observer_height`` controls the z-coordinate of the sensor origin when
-    the owner is a ground agent (default 1.6m, eye height).
-    """
-
-    def __init__(
-        self,
-        ctx: IContext,
-        sensor_id: str,
-        sensor_type: SensorType,
-        sensor_range: float,
-        fov: float,
-        orientation: Tuple[float, float] = (1.0, 0.0),
-        observer_height: float = 1.6,
-    ) -> None:
-        super().__init__(ctx, sensor_id, sensor_type, sensor_range, fov, orientation)
-        self.observer_height = observer_height
-
-    def _origin(self, current_node: Node) -> Tuple[float, float, float]:
-        if self._owner is not None:
-            agent = self.ctx.agent.get_agent(self._owner)
-            if getattr(agent, "type", None) == AgentType.AERIAL:
-                return cast(IAerialAgent, agent).position
-        return (current_node.x, current_node.y, self.observer_height)
-
-    def sense(self, node_id: int) -> None:
-        super().sense(node_id)
-        polygons = list(_iter_polygon_records(self.ctx))
-        if not polygons:
-            return
-        current_node = self.ctx.graph.graph.get_node(node_id)
-        origin = self._origin(current_node)
-        nodes = self._data.get('nodes', {})
-        edges = self._data.get('edges', [])
-        visible_nodes: Dict[int, Node] = {}
-        for nid, node in nodes.items():
-            target = (node.x, node.y, self.observer_height)
-            if not _is_segment_occluded(self.ctx, origin, target, polygons):
-                visible_nodes[nid] = node
-        visible_edges: List[OSMEdge] = []
-        for edge in edges:
-            if edge.source in visible_nodes and edge.target in visible_nodes:
-                visible_edges.append(edge)
-        self._data = {'nodes': visible_nodes, 'edges': visible_edges}
-
-
-class OccludedAgentSensor(AgentSensor):
-    """:class:`AgentSensor` variant that drops agents hidden behind polygons."""
-
-    def __init__(
-        self,
-        ctx: IContext,
-        sensor_id: str,
-        sensor_type: SensorType,
-        sensor_range: float,
-        fov: float = 2 * math.pi,
-        orientation: Tuple[float, float] = (1.0, 0.0),
-        owner: Optional[str] = None,
-        observer_height: float = 1.6,
-    ) -> None:
-        super().__init__(ctx, sensor_id, sensor_type, sensor_range, fov, orientation, owner)
-        self.observer_height = observer_height
-
-    def _origin(self, current_node: Node) -> Tuple[float, float, float]:
-        if self._owner is not None:
-            agent = self.ctx.agent.get_agent(self._owner)
-            if getattr(agent, "type", None) == AgentType.AERIAL:
-                return cast(IAerialAgent, agent).position
-        return (current_node.x, current_node.y, self.observer_height)
-
-    def sense(self, node_id: int) -> None:
-        super().sense(node_id)
-        polygons = list(_iter_polygon_records(self.ctx))
-        if not polygons:
-            return
-        current_node = self.ctx.graph.graph.get_node(node_id)
-        origin = self._origin(current_node)
-        sensed = self._data
-        kept: Dict[str, int] = {}
-        for agent_name, agent_node_id in sensed.items():
-            agent_node = self.ctx.graph.graph.get_node(agent_node_id)
-            target = (agent_node.x, agent_node.y, self.observer_height)
-            if not _is_segment_occluded(self.ctx, origin, target, polygons):
-                kept[agent_name] = agent_node_id
-        self._data = kept
-
-
-class OccludedAerialSensor(AerialSensor):
-    """:class:`AerialSensor` variant that drops occluded ground nodes/edges."""
-
-    def sense(self, node_id: int) -> None:
-        super().sense(node_id)
-        polygons = list(_iter_polygon_records(self.ctx))
-        if not polygons:
-            return
-        if self._owner is None:
-            return
-        agent = cast(IAerialAgent, self.ctx.agent.get_agent(self._owner))
-        origin = agent.position
-        nodes = self._data.get('nodes', {})
-        edges = self._data.get('edges', [])
-        visible_nodes: Dict[int, Node] = {}
-        for nid, node in nodes.items():
-            target = (node.x, node.y, 0.0)
-            if not _is_segment_occluded(self.ctx, origin, target, polygons):
-                visible_nodes[nid] = node
-        visible_edges: List[OSMEdge] = []
-        for edge in edges:
-            if edge.source in visible_nodes and edge.target in visible_nodes:
-                visible_edges.append(edge)
-        self._data = {'nodes': visible_nodes, 'edges': visible_edges}
-
-
-class OccludedAerialAgentSensor(AerialAgentSensor):
-    """:class:`AerialAgentSensor` variant that drops occluded agents."""
-
-    def sense(self, node_id: int) -> None:
-        super().sense(node_id)
-        polygons = list(_iter_polygon_records(self.ctx))
-        if not polygons:
-            return
-        if self._owner is None:
-            return
-        agent = cast(IAerialAgent, self.ctx.agent.get_agent(self._owner))
-        origin = agent.position
-        kept: Dict[str, Tuple[AgentType, Tuple[float, float, float]]] = {}
-        for name, (atype, pos) in self._data.items():
-            target = (pos[0], pos[1], pos[2])
-            if not _is_segment_occluded(self.ctx, origin, target, polygons):
-                kept[name] = (atype, pos)
-        self._data = kept
+from gamms.SensorEngine.sensors_basic import AgentSensor, MapSensor, NeighborSensor
+from gamms.SensorEngine.sensors_aerial import AerialAgentSensor, AerialSensor
+from gamms.SensorEngine.sensors_occluded import (
+    OccludedAerialAgentSensor,
+    OccludedAerialSensor,
+    OccludedAgentSensor,
+    OccludedMapSensor,
+)
 
 
 class SensorEngine(ISensorEngine):
@@ -636,54 +36,40 @@ class SensorEngine(ISensorEngine):
 
     def create_sensor(self, sensor_id: str, sensor_type: SensorType, **kwargs: Dict[str, Any]) -> ISensor:
         if sensor_type == SensorType.NEIGHBOR:
-            sensor = NeighborSensor(
-                self.ctx, sensor_id, sensor_type, 
-            )
+            sensor: ISensor = NeighborSensor(self.ctx, sensor_id, sensor_type)
         elif sensor_type == SensorType.MAP:
             sensor = MapSensor(
-                self.ctx, 
-                sensor_id, 
-                sensor_type, 
+                self.ctx, sensor_id, sensor_type,
                 sensor_range=float('inf'),
                 fov=2 * math.pi,
             )
         elif sensor_type == SensorType.RANGE:
             sensor = MapSensor(
-                self.ctx, 
-                sensor_id, 
-                sensor_type, 
+                self.ctx, sensor_id, sensor_type,
                 sensor_range=cast(float, kwargs.get('sensor_range', 30.0)),
-                fov=(2 * math.pi),
+                fov=2 * math.pi,
             )
         elif sensor_type == SensorType.ARC:
             sensor = MapSensor(
-                self.ctx, 
-                sensor_id, 
-                sensor_type, 
+                self.ctx, sensor_id, sensor_type,
                 sensor_range=cast(float, kwargs.get('sensor_range', 30.0)),
                 fov=cast(float, kwargs.get('fov', 2 * math.pi)),
             )
         elif sensor_type == SensorType.AGENT:
             sensor = AgentSensor(
-                self.ctx, 
-                sensor_id, 
-                sensor_type, 
+                self.ctx, sensor_id, sensor_type,
                 sensor_range=float('inf'),
                 fov=cast(float, kwargs.get('fov', 2 * math.pi)),
             )
         elif sensor_type == SensorType.AGENT_ARC:
             sensor = AgentSensor(
-                self.ctx, 
-                sensor_id, 
-                sensor_type, 
+                self.ctx, sensor_id, sensor_type,
                 sensor_range=cast(float, kwargs.get('sensor_range', 30.0)),
-                fov=cast(float, kwargs.get('fov', 2 * math.pi)), 
+                fov=cast(float, kwargs.get('fov', 2 * math.pi)),
             )
         elif sensor_type == SensorType.AGENT_RANGE:
             sensor = AgentSensor(
-                self.ctx, 
-                sensor_id, 
-                sensor_type, 
+                self.ctx, sensor_id, sensor_type,
                 sensor_range=cast(float, kwargs.get('sensor_range', 30.0)),
                 fov=2 * math.pi,
             )
@@ -691,15 +77,15 @@ class SensorEngine(ISensorEngine):
             sensor = AerialSensor(
                 self.ctx, sensor_id,
                 sensor_range=cast(float, kwargs.get('sensor_range', 100.0)),
-                fov=cast(float, kwargs.get('fov', math.pi/3)),  # Default 60° FOV
-                quat=kwargs.get('quat', (0.0, 0.0, 1.0, 0.0))  # Default downward-facing
+                fov=cast(float, kwargs.get('fov', math.pi / 3)),
+                quat=cast(tuple, kwargs.get('quat', (0.0, 0.0, 1.0, 0.0))),
             )
         elif sensor_type == SensorType.AERIAL_AGENT:
             sensor = AerialAgentSensor(
                 self.ctx, sensor_id,
                 sensor_range=cast(float, kwargs.get('sensor_range', 100.0)),
                 fov=cast(float, kwargs.get('fov', 2 * math.pi)),
-                quat=kwargs.get('quat', (1.0, 0.0, 0.0, 0.0))
+                quat=cast(tuple, kwargs.get('quat', (1.0, 0.0, 0.0, 0.0))),
             )
         elif sensor_type == SensorType.OCCLUDED_MAP:
             sensor = OccludedMapSensor(
@@ -747,21 +133,21 @@ class SensorEngine(ISensorEngine):
             sensor = OccludedAerialSensor(
                 self.ctx, sensor_id,
                 sensor_range=cast(float, kwargs.get('sensor_range', 100.0)),
-                fov=cast(float, kwargs.get('fov', math.pi/3)),
-                quat=kwargs.get('quat', (math.sqrt(0.5), 0.0, math.sqrt(0.5), 0.0)),
+                fov=cast(float, kwargs.get('fov', math.pi / 3)),
+                quat=cast(tuple, kwargs.get('quat', (math.sqrt(0.5), 0.0, math.sqrt(0.5), 0.0))),
             )
         elif sensor_type == SensorType.OCCLUDED_AERIAL_AGENT:
             sensor = OccludedAerialAgentSensor(
                 self.ctx, sensor_id,
                 sensor_range=cast(float, kwargs.get('sensor_range', 100.0)),
                 fov=cast(float, kwargs.get('fov', 2 * math.pi)),
-                quat=kwargs.get('quat', (1.0, 0.0, 0.0, 0.0)),
+                quat=cast(tuple, kwargs.get('quat', (1.0, 0.0, 0.0, 0.0))),
             )
         else:
             raise ValueError("Invalid sensor type")
         self.add_sensor(sensor)
         return sensor
-    
+
     def add_sensor(self, sensor: ISensor) -> None:
         sensor_id = sensor.sensor_id
         if sensor_id in self.sensors:
@@ -780,6 +166,7 @@ class SensorEngine(ISensorEngine):
         else:
             extend_enum(SensorType, name, len(SensorType))
         val = getattr(SensorType, name)
+
         def decorator(cls_type: ISensor) -> ISensor:
             cls_type.type = property(lambda obj: val)
             return cls_type

--- a/gamms/SensorEngine/sensors_aerial.py
+++ b/gamms/SensorEngine/sensors_aerial.py
@@ -1,0 +1,191 @@
+"""Aerial sensors: AerialSensor, AerialAgentSensor, plus quaternion helpers."""
+
+import math
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
+
+from gamms.typing import (
+    AgentType,
+    IAerialAgent,
+    IContext,
+    ISensor,
+    Node,
+    OSMEdge,
+    SensorType,
+)
+
+
+def multiply_quaternions(
+    q1: Tuple[float, float, float, float],
+    q2: Tuple[float, float, float, float],
+) -> Tuple[float, float, float, float]:
+    w1, x1, y1, z1 = q1
+    w2, x2, y2, z2 = q2
+    return (
+        w1*w2 - x1*x2 - y1*y2 - z1*z2,
+        w1*x2 + x1*w2 + y1*z2 - z1*y2,
+        w1*y2 - x1*z2 + y1*w2 + z1*x2,
+        w1*z2 + x1*y2 - y1*x2 + z1*w2,
+    )
+
+
+def quaternion_to_direction(
+    quat: Tuple[float, float, float, float],
+) -> Tuple[float, float, float]:
+    w, x, y, z = quat
+    return (
+        1 - 2*(y**2 + z**2),
+        2*(x*y + w*z),
+        2*(x*z - w*y),
+    )
+
+
+class AerialSensor(ISensor):
+    def __init__(
+        self,
+        ctx: IContext,
+        sensor_id: str,
+        sensor_range: float,
+        fov: float = math.pi / 3,
+        quat: Tuple[float, float, float, float] = (math.sqrt(0.5), 0.0, math.sqrt(0.5), 0.0),
+    ):
+        """
+        Downward-facing conic sensor for aerial agents.
+        """
+        self._sensor_id = sensor_id
+        self.ctx = ctx
+        self._data: Dict[str, Union[Dict[int, Node], List[OSMEdge]]] = {}
+        self._owner: Optional[str] = None
+        self.range = sensor_range
+        self.fov = min(fov, math.pi * 0.9)
+        self.quat = quat
+
+    @property
+    def sensor_id(self) -> str:
+        return self._sensor_id
+
+    @property
+    def type(self) -> SensorType:
+        return SensorType.AERIAL
+
+    @property
+    def data(self) -> Dict[str, Union[Dict[int, Node], List[OSMEdge]]]:
+        return self._data
+
+    def set_owner(self, owner: Union[str, None]) -> None:
+        if owner is not None:
+            agent = self.ctx.agent.get_agent(owner)
+            if agent.type != AgentType.AERIAL:
+                raise ValueError("Owner of AerialSensor must be an aerial agent")
+        self._owner = owner
+
+    def sense(self, node_id: int) -> None:
+        if self._owner is None:
+            self._data = {'nodes': {}, 'edges': []}
+            return
+        agent = cast(IAerialAgent, self.ctx.agent.get_agent(self._owner))
+        orientation = multiply_quaternions(agent.quat, self.quat)
+        fx, fy, fz = quaternion_to_direction(orientation)
+        x, y, z = agent.position
+        half_angle = self.fov / 2
+
+        sensed_nodes: Dict[int, Node] = {}
+        sensed_edges: List[OSMEdge] = []
+
+        for edge_id in self.ctx.graph.graph.get_edges(d=self.range, x=x, y=y):
+            edge = self.ctx.graph.graph.get_edge(edge_id)
+            source = self.ctx.graph.graph.get_node(edge.source)
+            target = self.ctx.graph.graph.get_node(edge.target)
+
+            normsq = (source.x - x)**2 + (source.y - y)**2 + z**2
+            cosine = (source.x - x) * fx + (source.y - y) * fy - z * fz
+            angle = math.acos(max(min(cosine / math.sqrt(normsq), 1.0), -1.0)) if normsq != 0 else 2 * math.pi
+            sbool = (normsq <= self.range**2) and (angle <= half_angle)
+
+            normsq = (target.x - x)**2 + (target.y - y)**2 + z**2
+            cosine = (target.x - x) * fx + (target.y - y) * fy - z * fz
+            angle = math.acos(max(min(cosine / math.sqrt(normsq), 1.0), -1.0)) if normsq != 0 else 2 * math.pi
+            tbool = (normsq <= self.range**2) and (angle <= half_angle)
+
+            if sbool:
+                sensed_nodes[source.id] = source
+            if tbool:
+                sensed_nodes[target.id] = target
+            if sbool and tbool:
+                sensed_edges.append(edge)
+
+        self._data = {'nodes': sensed_nodes, 'edges': sensed_edges}
+
+    def update(self, data: Dict[str, Any]) -> None:
+        pass
+
+
+class AerialAgentSensor(ISensor):
+    def __init__(
+        self,
+        ctx: IContext,
+        sensor_id: str,
+        sensor_range: float,
+        fov: float = 2 * math.pi,
+        quat: Tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
+    ):
+        self._sensor_id = sensor_id
+        self.ctx = ctx
+        self.range = sensor_range
+        self.fov = fov
+        self.quat = quat
+        self._owner: Optional[str] = None
+        self._data: Dict[str, Tuple[AgentType, Tuple[float, float, float]]] = {}
+
+    @property
+    def sensor_id(self) -> str:
+        return self._sensor_id
+
+    @property
+    def type(self) -> SensorType:
+        return SensorType.AERIAL_AGENT
+
+    @property
+    def data(self) -> Dict[str, Tuple[AgentType, Tuple[float, float, float]]]:
+        return self._data
+
+    def set_owner(self, owner: Union[str, None]) -> None:
+        agent = self.ctx.agent.get_agent(owner) if owner else None
+        if agent is not None:
+            if agent.type != AgentType.AERIAL:
+                raise ValueError("Owner of AerialAgentSensor must be an aerial agent")
+        self._owner = owner
+
+    def sense(self, node_id: int) -> None:
+        if self._owner is None:
+            self._data = {}
+            return
+        agent = cast(IAerialAgent, self.ctx.agent.get_agent(self._owner))
+        quat = multiply_quaternions(agent.quat, self.quat)
+        fx, fy, fz = quaternion_to_direction(quat)
+        x, y, z = agent.position
+
+        sensed_agents: Dict[str, Tuple[AgentType, Tuple[float, float, float]]] = {}
+        for other in self.ctx.agent.create_iter():
+            if other.name == self._owner:
+                continue
+            if other.type == AgentType.AERIAL:
+                agent_pos = cast(IAerialAgent, other).position
+            elif other.type == AgentType.BASIC:
+                agent_node = self.ctx.graph.graph.get_node(other.current_node_id)
+                agent_pos = (agent_node.x, agent_node.y, 0.0)
+            else:
+                raise RuntimeError(f"Unknown agent type {other.type} for agent {other.name}")
+
+            dx = agent_pos[0] - x
+            dy = agent_pos[1] - y
+            dz = agent_pos[2] - z
+            distance_3d = dx**2 + dy**2 + dz**2
+            cosine = dx * fx + dy * fy + dz * fz
+            angle = math.acos(max(min(cosine / math.sqrt(distance_3d), 1.0), -1.0)) if distance_3d != 0 else 2 * math.pi
+            if (distance_3d <= self.range**2) and (angle <= self.fov / 2):
+                sensed_agents[other.name] = (other.type, agent_pos)
+
+        self._data = sensed_agents
+
+    def update(self, data: Dict[str, Any]) -> None:
+        pass

--- a/gamms/SensorEngine/sensors_basic.py
+++ b/gamms/SensorEngine/sensors_basic.py
@@ -1,0 +1,201 @@
+"""Basic ground-level sensors: NeighborSensor, MapSensor, AgentSensor."""
+
+import math
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from gamms.typing import (
+    IContext,
+    ISensor,
+    Node,
+    OSMEdge,
+    SensorType,
+)
+
+
+class NeighborSensor(ISensor):
+    def __init__(self, ctx: IContext, sensor_id: str, sensor_type: SensorType):
+        self._sensor_id = sensor_id
+        self.ctx = ctx
+        self._type = sensor_type
+        self._data: List[int] = []
+        self._owner: Optional[str] = None
+
+    @property
+    def sensor_id(self) -> str:
+        return self._sensor_id
+
+    @property
+    def type(self) -> SensorType:
+        return self._type
+
+    @property
+    def data(self):
+        return self._data
+
+    def set_owner(self, owner: Union[str, None]) -> None:
+        self._owner = owner
+
+    def sense(self, node_id: int) -> None:
+        nearest_neighbors = {node_id}
+        for nid in self.ctx.graph.graph.get_neighbors(node_id):
+            nearest_neighbors.add(nid)
+        self._data = list(nearest_neighbors)
+
+    def update(self, data: Dict[str, Any]) -> None:
+        pass
+
+
+class MapSensor(ISensor):
+    def __init__(
+        self,
+        ctx: IContext,
+        sensor_id: str,
+        sensor_type: SensorType,
+        sensor_range: float,
+        fov: float,
+        orientation: Tuple[float, float] = (1.0, 0.0),
+    ):
+        """
+        Acts as a map sensor (range == inf), a range sensor (fov == 2π),
+        or a unidirectional sensor (fov < 2π). FOV/orientation in radians.
+        """
+        self.ctx = ctx
+        self._sensor_id = sensor_id
+        self._type = sensor_type
+        self.range = sensor_range
+        self.fov = fov
+        norm = math.sqrt(orientation[0]**2 + orientation[1]**2)
+        self.orientation = (orientation[0] / norm, orientation[1] / norm)
+        self._data: Dict[str, Union[Dict[int, Node], List[OSMEdge]]] = {}
+        self._owner: Optional[str] = None
+
+    @property
+    def sensor_id(self) -> str:
+        return self._sensor_id
+
+    @property
+    def type(self) -> SensorType:
+        return self._type
+
+    @property
+    def data(self) -> Dict[str, Union[Dict[int, Node], List[OSMEdge]]]:
+        return self._data
+
+    def set_owner(self, owner: Union[str, None]) -> None:
+        self._owner = owner
+
+    def sense(self, node_id: int) -> None:
+        current_node = self.ctx.graph.graph.get_node(node_id)
+        if self._owner is not None:
+            owner_orientation = self.ctx.agent.get_agent(self._owner).orientation
+            orientation_used = (
+                self.orientation[0] * owner_orientation[0] - self.orientation[1] * owner_orientation[1],
+                self.orientation[0] * owner_orientation[1] + self.orientation[1] * owner_orientation[0],
+            )
+        else:
+            orientation_used = self.orientation
+
+        if self.range == float('inf'):
+            edge_iter = self.ctx.graph.graph.get_edges()
+        else:
+            edge_iter = self.ctx.graph.graph.get_edges(d=self.range, x=current_node.x, y=current_node.y)
+
+        sensed_nodes: Dict[int, Node] = {}
+        sensed_edges: List[OSMEdge] = []
+
+        range_sq = self.range ** 2 if self.range != float('inf') else float('inf')
+
+        for edge_id in edge_iter:
+            edge = self.ctx.graph.graph.get_edge(edge_id)
+            source = self.ctx.graph.graph.get_node(edge.source)
+            target = self.ctx.graph.graph.get_node(edge.target)
+            sbool = (source.x - current_node.x)**2 + (source.y - current_node.y)**2 <= range_sq
+            tbool = (target.x - current_node.x)**2 + (target.y - current_node.y)**2 <= range_sq
+            if not (self.fov == 2 * math.pi or orientation_used == (0.0, 0.0)):
+                angle = math.atan2(source.y - current_node.y, source.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                angle = (angle % (2 * math.pi)) - math.pi
+                sbool &= (abs(angle) <= self.fov / 2) or (source.id == node_id)
+                angle = math.atan2(target.y - current_node.y, target.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                angle = (angle % (2 * math.pi)) - math.pi
+                tbool &= (abs(angle) <= self.fov / 2) or (target.id == node_id)
+            if sbool:
+                sensed_nodes[source.id] = source
+            if tbool:
+                sensed_nodes[target.id] = target
+            if sbool and tbool:
+                sensed_edges.append(edge)
+
+        self._data = {'nodes': sensed_nodes, 'edges': sensed_edges}
+
+    def update(self, data: Dict[str, Any]) -> None:
+        pass
+
+
+class AgentSensor(ISensor):
+    def __init__(
+        self,
+        ctx: IContext,
+        sensor_id: str,
+        sensor_type: SensorType,
+        sensor_range: float,
+        fov: float = 2 * math.pi,
+        orientation: Tuple[float, float] = (1.0, 0.0),
+        owner: Optional[str] = None,
+    ):
+        self._sensor_id = sensor_id
+        self.ctx = ctx
+        self._type = sensor_type
+        self.range = sensor_range
+        self.fov = fov
+        self.orientation = orientation
+        self._owner = owner
+        self._data: Dict[str, int] = {}
+
+    @property
+    def sensor_id(self) -> str:
+        return self._sensor_id
+
+    @property
+    def type(self) -> SensorType:
+        return self._type
+
+    @property
+    def data(self) -> Dict[str, int]:
+        return self._data
+
+    def set_owner(self, owner: Union[str, None]) -> None:
+        self._owner = owner
+
+    def sense(self, node_id: int) -> None:
+        current_node = self.ctx.graph.graph.get_node(node_id)
+        if self._owner is not None:
+            owner_orientation = self.ctx.agent.get_agent(self._owner).orientation
+            orientation_used = (
+                self.orientation[0] * owner_orientation[0] - self.orientation[1] * owner_orientation[1],
+                self.orientation[0] * owner_orientation[1] + self.orientation[1] * owner_orientation[0],
+            )
+        else:
+            orientation_used = self.orientation
+
+        sensed_agents: Dict[str, int] = {}
+        range_sq = self.range ** 2 if self.range != float('inf') else float('inf')
+
+        for agent in self.ctx.agent.create_iter():
+            if agent.name == self._owner:
+                continue
+            agent_node = self.ctx.graph.graph.get_node(agent.current_node_id)
+            distance_sq = (agent_node.x - current_node.x)**2 + (agent_node.y - current_node.y)**2
+
+            if distance_sq <= range_sq:
+                if self.fov == 2 * math.pi or orientation_used == (0.0, 0.0):
+                    sensed_agents[agent.name] = agent.current_node_id
+                else:
+                    angle = math.atan2(agent_node.y - current_node.y, agent_node.x - current_node.x) - math.atan2(orientation_used[1], orientation_used[0]) + math.pi
+                    angle = (angle % (2 * math.pi)) - math.pi
+                    if abs(angle) <= self.fov / 2 or agent.current_node_id == node_id:
+                        sensed_agents[agent.name] = agent.current_node_id
+
+        self._data = sensed_agents
+
+    def update(self, data: Dict[str, Any]) -> None:
+        pass

--- a/gamms/SensorEngine/sensors_occluded.py
+++ b/gamms/SensorEngine/sensors_occluded.py
@@ -1,0 +1,209 @@
+"""Occlusion-aware sensors. One general class per axis.
+
+The factory wires the backward-compat ``OCCLUDED_RANGE`` / ``OCCLUDED_ARC``
+/ ``OCCLUDED_AGENT_RANGE`` / ``OCCLUDED_AGENT_ARC`` enum values to these
+classes with the appropriate kwargs — there is no longer a separate class
+per arc/range variant.
+"""
+
+import math
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, cast
+
+from gamms.typing import (
+    AgentType,
+    IAerialAgent,
+    IContext,
+    Node,
+    OSMEdge,
+    SensorType,
+)
+from gamms.SensorEngine.sensors_basic import AgentSensor, MapSensor
+from gamms.SensorEngine.sensors_aerial import AerialAgentSensor, AerialSensor
+from gamms.SensorEngine.occlusion import segment_blocked_by_polygon
+
+
+def _polygons_in_range(
+    ctx: IContext,
+    x: float,
+    y: float,
+    radius: float,
+) -> List[Dict[str, Any]]:
+    """Pull polygon records whose bbox overlaps the sensor range.
+
+    Falls back to scanning all polygons when the graph engine doesn't
+    expose a range-aware ``get_polygons`` (older custom engines).
+    """
+    graph_engine = ctx.graph
+    if graph_engine is None:
+        return []
+    get_polygons = getattr(graph_engine, "get_polygons", None)
+    get_polygon = getattr(graph_engine, "get_polygon", None)
+    if not callable(get_polygons) or not callable(get_polygon):
+        return []
+    try:
+        if math.isfinite(radius) and radius >= 0:
+            ids = list(get_polygons(radius, x, y))
+        else:
+            ids = list(get_polygons())
+    except (RuntimeError, TypeError):
+        try:
+            ids = list(get_polygons())
+        except RuntimeError:
+            return []
+
+    polygons: List[Dict[str, Any]] = []
+    for pid in ids:
+        try:
+            polygons.append(get_polygon(pid))
+        except KeyError:
+            continue
+    return polygons
+
+
+def _is_blocked(
+    a: Tuple[float, float, float],
+    b: Tuple[float, float, float],
+    polygons: Iterable[Dict[str, Any]],
+) -> bool:
+    for poly in polygons:
+        if segment_blocked_by_polygon(a, b, poly["coords"], poly.get("base", 0.0), poly["height"]):
+            return True
+    return False
+
+
+class OccludedMapSensor(MapSensor):
+    """``MapSensor`` variant that drops nodes/edges occluded by polygons.
+
+    Single class for ``OCCLUDED_MAP`` / ``OCCLUDED_RANGE`` / ``OCCLUDED_ARC``;
+    the variants differ only in the (range, fov) preset wired by the factory.
+    """
+
+    def __init__(
+        self,
+        ctx: IContext,
+        sensor_id: str,
+        sensor_type: SensorType,
+        sensor_range: float,
+        fov: float,
+        orientation: Tuple[float, float] = (1.0, 0.0),
+        observer_height: float = 1.6,
+    ) -> None:
+        super().__init__(ctx, sensor_id, sensor_type, sensor_range, fov, orientation)
+        self.observer_height = observer_height
+
+    def _origin(self, current_node: Node) -> Tuple[float, float, float]:
+        if self._owner is not None:
+            agent = self.ctx.agent.get_agent(self._owner)
+            if getattr(agent, "type", None) == AgentType.AERIAL:
+                return cast(IAerialAgent, agent).position
+        return (current_node.x, current_node.y, self.observer_height)
+
+    def sense(self, node_id: int) -> None:
+        super().sense(node_id)
+        current_node = self.ctx.graph.graph.get_node(node_id)
+        origin = self._origin(current_node)
+        polygons = _polygons_in_range(self.ctx, origin[0], origin[1], self.range)
+        if not polygons:
+            return
+        nodes = self._data.get('nodes', {})
+        edges = self._data.get('edges', [])
+        visible_nodes: Dict[int, Node] = {}
+        for nid, node in nodes.items():
+            target = (node.x, node.y, self.observer_height)
+            if not _is_blocked(origin, target, polygons):
+                visible_nodes[nid] = node
+        visible_edges: List[OSMEdge] = []
+        for edge in edges:
+            if edge.source in visible_nodes and edge.target in visible_nodes:
+                visible_edges.append(edge)
+        self._data = {'nodes': visible_nodes, 'edges': visible_edges}
+
+
+class OccludedAgentSensor(AgentSensor):
+    """``AgentSensor`` variant that drops agents hidden behind polygons.
+
+    Single class for ``OCCLUDED_AGENT`` / ``OCCLUDED_AGENT_RANGE`` /
+    ``OCCLUDED_AGENT_ARC``.
+    """
+
+    def __init__(
+        self,
+        ctx: IContext,
+        sensor_id: str,
+        sensor_type: SensorType,
+        sensor_range: float,
+        fov: float = 2 * math.pi,
+        orientation: Tuple[float, float] = (1.0, 0.0),
+        owner: Optional[str] = None,
+        observer_height: float = 1.6,
+    ) -> None:
+        super().__init__(ctx, sensor_id, sensor_type, sensor_range, fov, orientation, owner)
+        self.observer_height = observer_height
+
+    def _origin(self, current_node: Node) -> Tuple[float, float, float]:
+        if self._owner is not None:
+            agent = self.ctx.agent.get_agent(self._owner)
+            if getattr(agent, "type", None) == AgentType.AERIAL:
+                return cast(IAerialAgent, agent).position
+        return (current_node.x, current_node.y, self.observer_height)
+
+    def sense(self, node_id: int) -> None:
+        super().sense(node_id)
+        current_node = self.ctx.graph.graph.get_node(node_id)
+        origin = self._origin(current_node)
+        polygons = _polygons_in_range(self.ctx, origin[0], origin[1], self.range)
+        if not polygons:
+            return
+        kept: Dict[str, int] = {}
+        for agent_name, agent_node_id in self._data.items():
+            agent_node = self.ctx.graph.graph.get_node(agent_node_id)
+            target = (agent_node.x, agent_node.y, self.observer_height)
+            if not _is_blocked(origin, target, polygons):
+                kept[agent_name] = agent_node_id
+        self._data = kept
+
+
+class OccludedAerialSensor(AerialSensor):
+    """``AerialSensor`` variant that drops occluded ground nodes/edges."""
+
+    def sense(self, node_id: int) -> None:
+        super().sense(node_id)
+        if self._owner is None:
+            return
+        agent = cast(IAerialAgent, self.ctx.agent.get_agent(self._owner))
+        origin = agent.position
+        polygons = _polygons_in_range(self.ctx, origin[0], origin[1], self.range)
+        if not polygons:
+            return
+        nodes = self._data.get('nodes', {})
+        edges = self._data.get('edges', [])
+        visible_nodes: Dict[int, Node] = {}
+        for nid, node in nodes.items():
+            target = (node.x, node.y, 0.0)
+            if not _is_blocked(origin, target, polygons):
+                visible_nodes[nid] = node
+        visible_edges: List[OSMEdge] = []
+        for edge in edges:
+            if edge.source in visible_nodes and edge.target in visible_nodes:
+                visible_edges.append(edge)
+        self._data = {'nodes': visible_nodes, 'edges': visible_edges}
+
+
+class OccludedAerialAgentSensor(AerialAgentSensor):
+    """``AerialAgentSensor`` variant that drops occluded agents."""
+
+    def sense(self, node_id: int) -> None:
+        super().sense(node_id)
+        if self._owner is None:
+            return
+        agent = cast(IAerialAgent, self.ctx.agent.get_agent(self._owner))
+        origin = agent.position
+        polygons = _polygons_in_range(self.ctx, origin[0], origin[1], self.range)
+        if not polygons:
+            return
+        kept: Dict[str, Tuple[AgentType, Tuple[float, float, float]]] = {}
+        for name, (atype, pos) in self._data.items():
+            target = (pos[0], pos[1], pos[2])
+            if not _is_blocked(origin, target, polygons):
+                kept[name] = (atype, pos)
+        self._data = kept

--- a/gamms/typing/graph_engine.py
+++ b/gamms/typing/graph_engine.py
@@ -244,6 +244,77 @@ class IGraph(ABC):
         """
         pass
 
+    @abstractmethod
+    def add_polygon(
+        self,
+        polygon_id: int,
+        coords: Any,
+        height: float = 6.0,
+        base: float = 0.0,
+        category: str = "building",
+        attributes: Dict[str, Any] = None,
+    ) -> None:
+        """
+        Add a polygonal occluder to the graph's polygon store.
+
+        Each polygon is treated as a 3D prism with vertical trapezoidal faces
+        between ``base`` and ``base + height``.
+
+        Args:
+            polygon_id: Unique identifier for the polygon.
+            coords: Iterable of ``(x, y)`` tuples describing the exterior ring.
+            height: Polygon height (must be positive).
+            base: z-coordinate of the polygon base.
+            category: Free-form classification (e.g. "building", "foliage").
+            attributes: Optional metadata dict.
+
+        Raises:
+            ValueError: If the polygon already exists or coordinates are invalid.
+        """
+        pass
+
+    @abstractmethod
+    def get_polygon(self, polygon_id: int) -> Dict[str, Any]:
+        """
+        Retrieve a polygon record by id.
+
+        Returns:
+            Dict[str, Any]: A dict with ``id``, ``coords``, ``height``,
+                ``base``, ``category``, ``attributes`` entries.
+
+        Raises:
+            KeyError: If the polygon does not exist.
+        """
+        pass
+
+    @abstractmethod
+    @overload
+    def get_polygons(self) -> Iterator[int]:
+        """
+        Iterate over the IDs of all polygons currently registered with the graph.
+        """
+        pass
+
+    @abstractmethod
+    @overload
+    def get_polygons(self, d: float, x: float, y: float) -> Iterator[int]:
+        """
+        Iterate over polygon IDs whose bounding box overlaps the square of
+        side ``2d`` centered on ``(x, y)``.
+
+        If ``d`` is non-negative, returns only polygons within range. May
+        return polygons whose bbox extends slightly past the range; will
+        always return polygons whose footprint touches the range.
+        """
+        pass
+
+    @abstractmethod
+    def remove_polygon(self, polygon_id: int) -> None:
+        """
+        Remove the polygon with the given identifier from the polygon store.
+        """
+        pass
+
 
 class IGraphEngine(ABC):
     """
@@ -330,10 +401,20 @@ class IGraphEngine(ABC):
         pass
 
     @abstractmethod
+    @overload
     def get_polygons(self) -> Iterator[int]:
         """
         Iterate over the IDs of all polygons currently registered with the
         engine.
+        """
+        pass
+
+    @abstractmethod
+    @overload
+    def get_polygons(self, d: float, x: float, y: float) -> Iterator[int]:
+        """
+        Iterate over polygon IDs whose bounding box overlaps the square of
+        side ``2d`` centered on ``(x, y)``.
         """
         pass
 

--- a/tests/memory_engine_test.py
+++ b/tests/memory_engine_test.py
@@ -3,115 +3,203 @@ import tempfile
 import unittest
 
 import gamms
-from gamms.MemoryEngine import MemoryEngine, MemoryStore, SqliteStore, PathLike
+from gamms.MemoryEngine import MemoryEngine, MemoryStore, PathLike, SqliteStore
 from gamms.typing.memory_engine import StoreType
 
 
-class MemoryStoreTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.engine = MemoryEngine()
-
-    def tearDown(self) -> None:
-        self.engine.terminate()
-
-    def test_create_and_get_store(self):
-        store = self.engine.create_store(StoreType.MEMORY, 'cars')
-        self.assertEqual(store.name, 'cars')
-        self.assertEqual(store.store_type, StoreType.MEMORY)
-        self.assertIs(store, self.engine.get_store('cars'))
-        self.assertIn('cars', self.engine.list_stores())
-
-    def test_duplicate_store_raises(self):
-        self.engine.create_store(StoreType.MEMORY, 'a')
-        with self.assertRaises(ValueError):
-            self.engine.create_store(StoreType.MEMORY, 'a')
-
-    def test_unknown_store_raises(self):
-        with self.assertRaises(KeyError):
-            self.engine.get_store('does-not-exist')
-
-    def test_map_lifecycle(self):
-        store = self.engine.create_store(StoreType.MEMORY, 's')
-        self.assertFalse(store.has_map('m'))
-        store.create_map('m', value_type=dict)
-        self.assertTrue(store.has_map('m'))
-        self.assertIn('m', store.list_maps())
-
-        store.insert_data('m', 1, {'name': 'foo'})
-        self.assertTrue(store.has_data('m', 1))
-        self.assertEqual(store.get_data('m', 1)['name'], 'foo')
-
-        store.update_data('m', 1, {'name': 'bar'})
-        self.assertEqual(store.get_data('m', 1)['name'], 'bar')
-        self.assertEqual(list(store.keys('m')), [1])
-
-        store.delete_data('m', 1)
-        self.assertFalse(store.has_data('m', 1))
-        with self.assertRaises(KeyError):
-            store.get_data('m', 1)
-        with self.assertRaises(KeyError):
-            store.delete_data('m', 1)
-
-    def test_duplicate_key_raises(self):
-        store = self.engine.create_store(StoreType.MEMORY, 's')
-        store.create_map('m')
-        store.insert_data('m', 'k', 1)
-        with self.assertRaises(ValueError):
-            store.insert_data('m', 'k', 2)
-
-    def test_create_duplicate_map_raises(self):
-        store = self.engine.create_store(StoreType.MEMORY, 's')
-        store.create_map('m')
-        with self.assertRaises(ValueError):
-            store.create_map('m')
-
-    def test_unknown_map_raises(self):
-        store = self.engine.create_store(StoreType.MEMORY, 's')
-        with self.assertRaises(KeyError):
-            store.insert_data('nope', 1, 1)
-        with self.assertRaises(KeyError):
-            store.get_data('nope', 1)
-        with self.assertRaises(KeyError):
-            list(store.keys('nope'))
+def _row_to_dict(row):
+    return dict(row)
 
 
-class SqliteStoreTest(unittest.TestCase):
+class _StoreContractMixin:
+    """Shared assertions exercised against both store backends."""
+
+    store_type: StoreType
+    requires_path: bool
+
+    def make_engine(self) -> MemoryEngine:
+        return MemoryEngine()
+
+    def make_path(self, name: str = 'data.db'):
+        if not self.requires_path:
+            return None
+        return PathLike(os.path.join(self.tmpdir.name, name))
+
     def setUp(self) -> None:
         self.tmpdir = tempfile.TemporaryDirectory()
-        self.path = PathLike(os.path.join(self.tmpdir.name, 'data.db'))
-        self.engine = MemoryEngine()
-        self.store = self.engine.create_store(StoreType.DATABASE, 'sqlite_store', self.path)
+        self.engine = self.make_engine()
+        self.store = self.engine.create_store(self.store_type, 's', self.make_path())
 
     def tearDown(self) -> None:
         self.engine.terminate()
         self.tmpdir.cleanup()
 
-    def test_persisted_round_trip(self):
-        self.store.create_map('items', value_type=dict)
-        self.store.insert_data('items', 'k1', {'value': 42})
-        self.store.insert_data('items', 'k2', {'value': 7})
-        self.assertEqual(set(self.store.keys('items')), {'k1', 'k2'})
-        self.assertEqual(self.store.get_data('items', 'k1'), {'value': 42})
+    def test_store_meta(self):
+        self.assertEqual(self.store.name(), 's')
+        self.assertEqual(self.store.type, self.store_type)
 
-        # Reopen using load_store; the same data should reappear.
-        engine2 = MemoryEngine()
-        store2 = engine2.load_store(StoreType.DATABASE, 'sqlite_store', self.path)
-        self.assertTrue(store2.has_map('items'))
-        self.assertEqual(store2.get_data('items', 'k1'), {'value': 42})
-        self.assertEqual(store2.get_data('items', 'k2'), {'value': 7})
-        engine2.terminate()
+    def test_basic_lifecycle(self):
+        self.store.create_map('items', {'id': int, 'name': str}, 'id')
+        self.assertIn('items', self.store.list_maps())
+
+        self.store.insert_data('items', {'id': 1, 'name': 'foo'})
+        self.assertEqual(_row_to_dict(self.store.get_data('items', 1)), {'id': 1, 'name': 'foo'})
+
+        self.store.update_data('items', {'id': 1, 'name': 'bar'})
+        self.assertEqual(_row_to_dict(self.store.get_data('items', 1))['name'], 'bar')
+        self.assertEqual(list(self.store.query_keys('items')), [1])
+
+        self.store.delete_data('items', 1)
+        with self.assertRaises(IndexError):
+            self.store.get_data('items', 1)
+        with self.assertRaises(IndexError):
+            self.store.delete_data('items', 1)
+
+    def test_duplicate_key_raises(self):
+        self.store.create_map('m', {'id': int, 'value': int}, 'id')
+        self.store.insert_data('m', {'id': 1, 'value': 10})
+        with self.assertRaises(ValueError):
+            self.store.insert_data('m', {'id': 1, 'value': 20})
+
+    def test_create_duplicate_map_raises(self):
+        self.store.create_map('m', {'id': int}, 'id')
+        with self.assertRaises(ValueError):
+            self.store.create_map('m', {'id': int}, 'id')
+
+    def test_unknown_map_raises(self):
+        with self.assertRaises(KeyError):
+            self.store.insert_data('nope', {'id': 1})
+        with self.assertRaises(KeyError):
+            self.store.get_data('nope', 1)
+        with self.assertRaises(KeyError):
+            list(self.store.query_keys('nope'))
+
+    def test_delete_map(self):
+        self.store.create_map('m', {'id': int}, 'id')
+        self.store.delete_map('m')
+        self.assertNotIn('m', self.store.list_maps())
+        with self.assertRaises(KeyError):
+            self.store.delete_map('m')
+
+    def test_invalid_primary_key_raises(self):
+        with self.assertRaises(IndexError):
+            self.store.create_map('m', {'id': int}, 'pk')
+
+    def test_unsupported_type_raises(self):
+        class Custom:
+            pass
+        with self.assertRaises(TypeError):
+            self.store.create_map('m', {'id': int, 'thing': Custom}, 'id')
+
+    def test_collection_field_round_trip(self):
+        self.store.create_map(
+            'm',
+            {'id': int, 'tags': list, 'meta': dict, 'pts': tuple},
+            'id',
+        )
+        self.store.insert_data('m', {
+            'id': 1,
+            'tags': ['a', 'b'],
+            'meta': {'k': 'v', 'n': 7},
+            'pts': ((1.0, 2.0), (3.0, 4.0)),
+        })
+        row = _row_to_dict(self.store.get_data('m', 1))
+        self.assertEqual(list(row['tags']), ['a', 'b'])
+        self.assertEqual(row['meta'], {'k': 'v', 'n': 7})
+        self.assertEqual(row['pts'], ((1.0, 2.0), (3.0, 4.0)))
+
+    def test_bulk_insert_and_count(self):
+        self.store.create_map('m', {'id': int, 'value': int}, 'id')
+        self.store.bulk_insert('m', [
+            {'id': 1, 'value': 1},
+            {'id': 2, 'value': 2},
+            {'id': 3, 'value': 3},
+        ])
+        self.assertEqual(self.store.count('m'), 3)
+        self.assertEqual(set(self.store.query_keys('m')), {1, 2, 3})
+
+    def test_create_index(self):
+        self.store.create_map('m', {'id': int, 'x': float, 'y': float}, 'id')
+        self.store.create_index('m', ('x', 'y'))
+
+
+class MemoryStoreTest(_StoreContractMixin, unittest.TestCase):
+    store_type = StoreType.MEMORY
+    requires_path = False
+
+    def test_get_map_backend_handle(self):
+        self.store.create_map('m', {'id': int, 'name': str}, 'id')
+        self.store.insert_data('m', {'id': 1, 'name': 'foo'})
+        backing = self.store.get_map('m')
+        self.assertEqual(backing[1], {'id': 1, 'name': 'foo'})
+
+
+class SqliteStoreTest(_StoreContractMixin, unittest.TestCase):
+    store_type = StoreType.DATABASE
+    requires_path = True
 
     def test_database_requires_path(self):
         with self.assertRaises(ValueError):
             self.engine.create_store(StoreType.DATABASE, 'no_path')
 
+    def test_persistent_round_trip(self):
+        self.store.create_map('items', {'id': int, 'value': int}, 'id')
+        self.store.insert_data('items', {'id': 1, 'value': 42})
+        self.store.insert_data('items', {'id': 2, 'value': 7})
+        self.store.flush()
+        self.engine.terminate()
 
-class PolygonStoreOnGraphEngineTest(unittest.TestCase):
+        # Reopen against the same path.
+        engine2 = MemoryEngine()
+        path = PathLike(os.path.join(self.tmpdir.name, 'data.db'))
+        store2 = engine2.create_store(StoreType.DATABASE, 's2', path)
+        self.assertIn('items', store2.list_maps())
+        self.assertEqual(_row_to_dict(store2.get_data('items', 1)), {'id': 1, 'value': 42})
+        self.assertEqual(_row_to_dict(store2.get_data('items', 2)), {'id': 2, 'value': 7})
+        engine2.terminate()
+
+
+class MemoryEngineRegistryTest(unittest.TestCase):
+    def test_create_and_get_store(self):
+        engine = MemoryEngine()
+        try:
+            store = engine.create_store(StoreType.MEMORY, 'cars')
+            self.assertEqual(store.name(), 'cars')
+            self.assertIs(store, engine.get_store('cars'))
+            self.assertIn('cars', list(engine.list_stores()))
+        finally:
+            engine.terminate()
+
+    def test_duplicate_store_raises(self):
+        engine = MemoryEngine()
+        try:
+            engine.create_store(StoreType.MEMORY, 'a')
+            with self.assertRaises(ValueError):
+                engine.create_store(StoreType.MEMORY, 'a')
+        finally:
+            engine.terminate()
+
+    def test_unknown_store_raises(self):
+        engine = MemoryEngine()
+        try:
+            with self.assertRaises(KeyError):
+                engine.get_store('does-not-exist')
+        finally:
+            engine.terminate()
+
+
+class _PolygonStoreSharedTest(unittest.TestCase):
+    """Polygon API works the same across both engine backends."""
+
+    graph_engine_kind = None
+
     def setUp(self) -> None:
+        if self.graph_engine_kind is None:
+            self.skipTest("base class")
         self.ctx = gamms.create_context(
             vis_engine=gamms.visual.Engine.NO_VIS,
             logger_config={'level': 'CRITICAL'},
-            graph_engine=gamms.graph.Engine.MEMORY,
+            graph_engine=self.graph_engine_kind,
         )
 
     def tearDown(self) -> None:
@@ -123,7 +211,6 @@ class PolygonStoreOnGraphEngineTest(unittest.TestCase):
         self.assertEqual(list(self.ctx.graph.get_polygons()), [0])
         record = self.ctx.graph.get_polygon(0)
         self.assertEqual(record['id'], 0)
-        # Default 2-storey building height (~6 m).
         self.assertEqual(record['height'], 6.0)
         self.assertEqual(record['category'], 'building')
 
@@ -138,21 +225,44 @@ class PolygonStoreOnGraphEngineTest(unittest.TestCase):
     def test_polygon_validation(self):
         with self.assertRaises(ValueError):
             self.ctx.graph.add_polygon(0, [(0, 0), (1, 1)])
-        # Closing vertex is dropped; the polygon below has only two distinct
-        # points and must be rejected.
         with self.assertRaises(ValueError):
             self.ctx.graph.add_polygon(0, [(0, 0), (1, 1), (0, 0)])
         with self.assertRaises(ValueError):
             self.ctx.graph.add_polygon(0, [(0, 0), (1, 0), (1, 1)], height=0)
+
+    def test_polygon_range_query(self):
+        # Two polygons: one near origin, one far away.
+        self.ctx.graph.add_polygon(0, [(0, 0), (5, 0), (5, 5), (0, 5)])
+        self.ctx.graph.add_polygon(1, [(200, 200), (210, 200), (210, 210), (200, 210)])
+        all_ids = set(self.ctx.graph.get_polygons())
+        self.assertEqual(all_ids, {0, 1})
+        near = set(self.ctx.graph.get_polygons(20.0, 0.0, 0.0))
+        self.assertEqual(near, {0})
+        far = set(self.ctx.graph.get_polygons(20.0, 200.0, 200.0))
+        self.assertEqual(far, {1})
 
     def test_internal_context_is_initialised(self):
         self.assertIsNotNone(self.ctx.ictx)
         self.assertIsNotNone(self.ctx.ictx.memory)
 
 
+class PolygonStoreOnGraphMemoryTest(_PolygonStoreSharedTest):
+    graph_engine_kind = gamms.graph.Engine.MEMORY
+
+
+class PolygonStoreOnGraphSqliteTest(_PolygonStoreSharedTest):
+    graph_engine_kind = gamms.graph.Engine.SQLITE
+
+
 def suite():
     s = unittest.TestSuite()
-    for cls in (MemoryStoreTest, SqliteStoreTest, PolygonStoreOnGraphEngineTest):
+    for cls in (
+        MemoryStoreTest,
+        SqliteStoreTest,
+        MemoryEngineRegistryTest,
+        PolygonStoreOnGraphMemoryTest,
+        PolygonStoreOnGraphSqliteTest,
+    ):
         s.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(cls))
     return s
 

--- a/tests/occlusion_test.py
+++ b/tests/occlusion_test.py
@@ -151,6 +151,26 @@ class OccludedSensorTest(unittest.TestCase):
         # avoid the wall; node 1 should still be visible.
         self.assertIn(1, sensor.data['nodes'])
 
+    def test_occluded_range_ignores_polygons_outside_range(self):
+        # A polygon far outside the sensor range must not affect the result.
+        self._add_blocking_wall()  # the relevant occluder near the agent
+        # An unrelated polygon way off to the side, well outside any sensor range.
+        self.ctx.graph.add_polygon(
+            99,
+            coords=[(500, 500), (510, 500), (510, 510), (500, 510)],
+            height=20.0,
+        )
+        sensor = self.ctx.sensor.create_sensor(
+            'occluded_filtered',
+            gamms.typing.SensorType.OCCLUDED_RANGE,
+            sensor_range=20.0,
+        )
+        sensor.sense(0)
+        # Occlusion behaviour must match the wall-only case: node 1 hidden,
+        # node 2 visible. The far polygon doesn't sneak in.
+        self.assertNotIn(1, sensor.data['nodes'])
+        self.assertIn(2, sensor.data['nodes'])
+
     def test_occluded_aerial_loses_node_when_low(self):
         self._add_blocking_wall()
         aerial = self.ctx.agent.create_agent(


### PR DESCRIPTION
Rewrites MemoryStore and SqliteStore against the schema-based IStore without leaking graph-specific concerns into the storage layer. Both graph backends keep their own optimizations and consume the store via a small generic extension API plus an honest backend handle. Polygons now live in the same engine-typed store as the graph and gain a bbox-indexed range query; occluded sensors use it to pre-filter polygon candidates. Sensor module split by behavioral group; occluded sensors collapse to one general class per axis with ARC/RANGE wired as factory presets.